### PR TITLE
{pyactr} Fix addition2 example

### DIFF
--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -131,7 +131,7 @@ func (p *PyACTR) WriteModel(path, initialGoal string) (outputFileName string, er
 	p.Writeln("")
 
 	memory := p.model.Memory
-	additionalInit := []string{"subsymbolic=True"}
+	additionalInit := []string{}
 
 	if memory.Latency != nil {
 		additionalInit = append(additionalInit, fmt.Sprintf("latency_factor=%s", framework.Float64Str(*memory.Latency)))
@@ -417,6 +417,7 @@ func (p *PyACTR) outputStatement(production *actr.Production, s *actr.Statement)
 			p.outputPattern(s.Set.Pattern, 2)
 		}
 	} else if s.Recall != nil {
+		p.Writeln("\t~retrieval>")
 		p.Writeln("\t+retrieval>")
 		p.outputPattern(s.Recall.Pattern, 2)
 	} else if s.Print != nil {


### PR DESCRIPTION
- turn off "subsymbolic" on the model
- clear the retrieval buffer before trying to fill it

This forces the pyactr productions to work like the ACT-R ones.

See: https://github.com/jakdot/pyactr/issues/9

Fixes #39