### PR TITLE
Generalize the framework interface's Run and WriteModel API

### DIFF
--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/asmaloney/gactar/actr"
-	"github.com/asmaloney/gactar/amod"
 	"github.com/asmaloney/gactar/framework"
 	"github.com/asmaloney/gactar/version"
 )
@@ -69,8 +68,8 @@ func (c *CCMPyACTR) SetModel(model *actr.Model) (err error) {
 
 // Run generates the python code from the amod file, writes it to disk, creates a "run" file
 // to actually run the model, and returns the output (stdout and stderr combined).
-func (c *CCMPyACTR) Run(initialGoal string) (generatedCode, output []byte, err error) {
-	runFile, err := c.WriteModel(c.tmpPath, initialGoal)
+func (c *CCMPyACTR) Run(initialBuffers framework.InitialBuffers) (generatedCode, output []byte, err error) {
+	runFile, err := c.WriteModel(c.tmpPath, initialBuffers)
 	if err != nil {
 		return
 	}
@@ -89,12 +88,12 @@ func (c *CCMPyACTR) Run(initialGoal string) (generatedCode, output []byte, err e
 }
 
 // WriteModel converts the internal actr.Model to python and writes it to a file.
-func (c *CCMPyACTR) WriteModel(path, initialGoal string) (outputFileName string, err error) {
-	goal, err := amod.ParseChunk(c.model, initialGoal)
+func (c *CCMPyACTR) WriteModel(path string, initialBuffers framework.InitialBuffers) (outputFileName string, err error) {
+	patterns, err := framework.ParseInitialBuffers(c.model, initialBuffers)
 	if err != nil {
-		err = fmt.Errorf("ERROR in initial goal - %s", err)
 		return
 	}
+	goal := patterns["goal"]
 
 	outputFileName = fmt.Sprintf("%s.py", c.className)
 	if path != "" {

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -15,11 +15,19 @@ type Framework interface {
 	Initialize() (err error)
 	SetModel(model *actr.Model) (err error)
 
-	Run(initialGoal string) (generatedCode, output []byte, err error)
-	WriteModel(path, initialGoal string) (outputFileName string, err error)
+	Run(initialBuffers InitialBuffers) (generatedCode, output []byte, err error)
+	WriteModel(path string, initialBuffers InitialBuffers) (outputFileName string, err error)
 }
 
 type List map[string]Framework
+
+// InitialBuffers is a map of buffer names to initial contents of the buffer.
+// This is used when passing in user-defined initial contents e.g. through a web API.
+type InitialBuffers map[string]string
+
+// ParsedInitialBuffers is a map of buffer name to a parsed version of the initial contents.
+// This is used when passing in user-defined initial contents e.g. through a web API.
+type ParsedInitialBuffers map[string]*actr.Pattern
 
 // Names returns all the names of the frameworks in the list.
 func (l List) Names() (names []string) {

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -12,7 +12,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/asmaloney/gactar/actr"
-	"github.com/asmaloney/gactar/amod"
 	"github.com/asmaloney/gactar/framework"
 	"github.com/asmaloney/gactar/version"
 )
@@ -68,8 +67,8 @@ func (p *PyACTR) SetModel(model *actr.Model) (err error) {
 	return
 }
 
-func (p *PyACTR) Run(initialGoal string) (generatedCode, output []byte, err error) {
-	outputFile, err := p.WriteModel(p.tmpPath, initialGoal)
+func (p *PyACTR) Run(initialBuffers framework.InitialBuffers) (generatedCode, output []byte, err error) {
+	outputFile, err := p.WriteModel(p.tmpPath, initialBuffers)
 	if err != nil {
 		return
 	}
@@ -89,12 +88,12 @@ func (p *PyACTR) Run(initialGoal string) (generatedCode, output []byte, err erro
 	return
 }
 
-func (p *PyACTR) WriteModel(path, initialGoal string) (outputFileName string, err error) {
-	goal, err := amod.ParseChunk(p.model, initialGoal)
+func (p *PyACTR) WriteModel(path string, initialBuffers framework.InitialBuffers) (outputFileName string, err error) {
+	patterns, err := framework.ParseInitialBuffers(p.model, initialBuffers)
 	if err != nil {
-		err = fmt.Errorf("ERROR in initial goal - %s", err)
 		return
 	}
+	goal := patterns["goal"]
 
 	// If our model has a print statement, then write out our support file
 	if p.model.HasPrintStatement() {

--- a/framework/tools.go
+++ b/framework/tools.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/asmaloney/gactar/actr"
+	"github.com/asmaloney/gactar/amod"
 )
 
 // Some tools for working with our frameworks
@@ -24,6 +25,28 @@ func IdentifyYourself(frameworkName, exeName string) {
 	output, _ = cmd.CombinedOutput()
 
 	fmt.Printf("%s: Using %s from %s", frameworkName, version, string(output))
+}
+
+func ParseInitialBuffers(model *actr.Model, initialBuffers InitialBuffers) (parsed ParsedInitialBuffers, err error) {
+	parsed = ParsedInitialBuffers{}
+
+	for bufferName, bufferInit := range initialBuffers {
+		buffer := model.LookupBuffer(bufferName)
+		if buffer == nil {
+			err = fmt.Errorf("ERROR cannot initialize buffer '%s' - not found in model '%s'", bufferName, model.Name)
+			return
+		}
+
+		pattern, parseErr := amod.ParseChunk(model, bufferInit)
+		if parseErr != nil {
+			err = fmt.Errorf("ERROR in initial buffer  '%s' - %s", bufferName, err)
+			return
+		}
+
+		parsed[bufferName] = pattern
+	}
+
+	return
 }
 
 // Float64Str takes a float and returns a string of the minimal representation.

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/asmaloney/gactar/actr"
-	"github.com/asmaloney/gactar/amod"
 	"github.com/asmaloney/gactar/framework"
 	"github.com/asmaloney/gactar/version"
 	"github.com/urfave/cli/v2"
@@ -57,8 +56,8 @@ func (v *VanillaACTR) SetModel(model *actr.Model) (err error) {
 	return
 }
 
-func (v *VanillaACTR) Run(initialGoal string) (generatedCode, output []byte, err error) {
-	modelFile, err := v.WriteModel(v.tmpPath, initialGoal)
+func (v *VanillaACTR) Run(initialBuffers framework.InitialBuffers) (generatedCode, output []byte, err error) {
+	modelFile, err := v.WriteModel(v.tmpPath, initialBuffers)
 	if err != nil {
 		return
 	}
@@ -89,12 +88,12 @@ func (v *VanillaACTR) Run(initialGoal string) (generatedCode, output []byte, err
 	return
 }
 
-func (v *VanillaACTR) WriteModel(path, initialGoal string) (outputFileName string, err error) {
-	goal, err := amod.ParseChunk(v.model, initialGoal)
+func (v *VanillaACTR) WriteModel(path string, initialBuffers framework.InitialBuffers) (outputFileName string, err error) {
+	patterns, err := framework.ParseInitialBuffers(v.model, initialBuffers)
 	if err != nil {
-		err = fmt.Errorf("ERROR in initial goal - %s", err)
 		return
 	}
+	goal := patterns["goal"]
 
 	outputFileName = fmt.Sprintf("%s.lisp", v.modelName)
 	if path != "" {

--- a/main.go
+++ b/main.go
@@ -183,8 +183,8 @@ func generateCode(frameworks *framework.List, files []string) {
 		return
 	}
 
-	for _, framework := range *frameworks {
-		err = framework.Initialize()
+	for _, f := range *frameworks {
+		err = f.Initialize()
 		if err != nil {
 			fmt.Println(err.Error())
 			continue
@@ -198,13 +198,13 @@ func generateCode(frameworks *framework.List, files []string) {
 				continue
 			}
 
-			err = framework.SetModel(model)
+			err = f.SetModel(model)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
 			}
 
-			fileName, err := framework.WriteModel("", "")
+			fileName, err := f.WriteModel("", framework.InitialBuffers{})
 			if err != nil {
 				fmt.Println(err.Error())
 				continue

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -198,17 +198,21 @@ func (s *Shell) cmdRun(initialGoal string) (err error) {
 		return
 	}
 
-	for name, framework := range *s.actrFrameworks {
+	for name, f := range *s.actrFrameworks {
 		if !s.activeFrameworks[name] {
 			continue
 		}
 
-		err = framework.SetModel(s.currentModel)
+		err = f.SetModel(s.currentModel)
 		if err != nil {
 			return err
 		}
 
-		_, output, err := framework.Run(initialGoal)
+		initialBuffers := framework.InitialBuffers{
+			"goal": strings.TrimSpace(initialGoal),
+		}
+
+		_, output, err := f.Run(initialBuffers)
 		if err != nil {
 			return err
 		}

--- a/web/web.go
+++ b/web/web.go
@@ -209,20 +209,22 @@ func (w *Web) listExamples(rw http.ResponseWriter, req *http.Request) {
 	})
 }
 
-func (w *Web) run(model *actr.Model, initialGoal string, framework framework.Framework) (generatedCode, output []byte, err error) {
+func (w *Web) run(model *actr.Model, initialGoal string, f framework.Framework) (generatedCode, output []byte, err error) {
 	if model == nil {
 		err = fmt.Errorf("no model loaded")
 		return
 	}
 
-	err = framework.SetModel(model)
+	err = f.SetModel(model)
 	if err != nil {
 		return
 	}
 
-	initialGoal = strings.TrimSpace(initialGoal)
+	initialBuffers := framework.InitialBuffers{
+		"goal": strings.TrimSpace(initialGoal),
+	}
 
-	generatedCode, output, err = framework.Run(initialGoal)
+	generatedCode, output, err = f.Run(initialBuffers)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Allow setting multiple initial buffer contents instead of only the goal.

Note: Currently the generated code only outputs the goal, but it is now set up so we can output others in the future.