### PR TITLE
{web} Add "api" prefix to all API endpoints

### DIFF
--- a/doc/Web API.md
+++ b/doc/Web API.md
@@ -2,6 +2,8 @@
 
 This document outlines the endpoints that are available when running gactar as a web server (i.e. by passing `-w` on the command line).
 
+All endpoints are prefixed by `/api/`.
+
 **Important Note:** The web API is intended for _local use only_. It should not be used to expose gactar to the internet. It is not designed for security or to prevent abuse.
 
 # General
@@ -23,7 +25,7 @@ Get the version of gactar being run.
 ### Example
 
 ```
-http://localhost:8181/version
+http://localhost:8181/api/version
 ```
 
 Result:
@@ -65,7 +67,7 @@ Map of results - one entry for each framework that was run.
 ### Example
 
 ```
- http://localhost:8181/run
+ http://localhost:8181/api/run
 ```
 
 Request payload:
@@ -120,7 +122,7 @@ Get a list of the available examples built-in to the server.
 ### Example
 
 ```
- http://localhost:8181/examples/list
+ http://localhost:8181/api/examples/list
 ```
 
 Result:
@@ -152,7 +154,7 @@ The amod code for the requested example. (Note that it is not JSON like the othe
 ### Example
 
 ```
- http://localhost:8181/examples/count.amod
+ http://localhost:8181/api/examples/count.amod
 ```
 
 Result:
@@ -183,7 +185,7 @@ name: count
 ### Example
 
 ```
- http://localhost:8181/session/begin
+ http://localhost:8181/api/session/begin
 ```
 
 Result:
@@ -209,7 +211,7 @@ Result:
 ### Example
 
 ```
- http://localhost:8181/session/end
+ http://localhost:8181/api/session/end
 ```
 
 Request payload:
@@ -267,7 +269,7 @@ Map of results - one entry for each framework that was run.
 ### Example
 
 ```
- http://localhost:8181/session/runModel
+ http://localhost:8181/api/session/runModel
 ```
 
 Request payload:
@@ -342,7 +344,7 @@ Given a model (amod code), compile and store it on the server. It returns an id 
 ### Example
 
 ```
- http://localhost:8181/model/load
+ http://localhost:8181/api/model/load
 ```
 
 Request payload:

--- a/web/examples.go
+++ b/web/examples.go
@@ -3,9 +3,9 @@ package web
 import "net/http"
 
 func initExamples(w *Web) {
-	exampleHandler := assetHandler(w.examples, "")
-	http.HandleFunc("/examples/", exampleHandler.ServeHTTP)
-	http.HandleFunc("/examples/list", w.listExamples)
+	exampleHandler := assetHandler(w.examples, "/api/", "")
+	http.HandleFunc("/api/examples/", exampleHandler.ServeHTTP)
+	http.HandleFunc("/api/examples/list", w.listExamples)
 }
 
 // listExamples simply returns a list of the examples included in the build.

--- a/web/gactar-web/src/App.vue
+++ b/web/gactar-web/src/App.vue
@@ -129,7 +129,7 @@ export default {
     async run() {
       this.running = true
       try {
-        const { data } = await this.$http.post('/run', {
+        const { data } = await this.$http.post('/api/run', {
           amod: this.code['amod'],
           goal: this.goal,
         })
@@ -147,7 +147,7 @@ export default {
 
     async getVersion() {
       try {
-        const { data } = await this.$http.get('/version')
+        const { data } = await this.$http.get('/api/version')
 
         this.version = data.version
       } catch (err) {

--- a/web/gactar-web/src/components/AmodCodeTab.vue
+++ b/web/gactar-web/src/components/AmodCodeTab.vue
@@ -117,7 +117,7 @@ export default {
 
     async getExample(example) {
       try {
-        const { data } = await this.$http.get('/examples/' + example)
+        const { data } = await this.$http.get('/api/examples/' + example)
         this.count += 1
         this.amodCode = data
       } catch (err) {
@@ -127,7 +127,7 @@ export default {
 
     async getExamples() {
       try {
-        const { data } = await this.$http.get('/examples/list')
+        const { data } = await this.$http.get('/api/examples/list')
         this.exampleFiles = data.example_list
       } catch (err) {
         this.$emit('showError', err)

--- a/web/model.go
+++ b/web/model.go
@@ -17,7 +17,7 @@ type Model struct {
 }
 
 func initModels(w *Web) {
-	http.HandleFunc("/model/load", w.loadModelHandler)
+	http.HandleFunc("/api/model/load", w.loadModelHandler)
 }
 
 func (w *Web) loadModelHandler(rw http.ResponseWriter, req *http.Request) {

--- a/web/session.go
+++ b/web/session.go
@@ -16,9 +16,9 @@ type Session struct {
 type SessionList []*Session
 
 func initSessions(w *Web) {
-	http.HandleFunc("/session/begin", w.beginSessionHandler)
-	http.HandleFunc("/session/runModel", w.runModelSessionHandler)
-	http.HandleFunc("/session/end", w.endSessionHandler)
+	http.HandleFunc("/api/session/begin", w.beginSessionHandler)
+	http.HandleFunc("/api/session/runModel", w.runModelSessionHandler)
+	http.HandleFunc("/api/session/end", w.endSessionHandler)
 }
 
 func (w *Web) beginSessionHandler(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
e.g. `/version` becomes `/api/version`

This lets us control paths better if we need different routes - e.g. when running a dev frontend.