### PR TITLE
Rework temp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__
 tmp
 .vscode
 env
+gactar-temp

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -25,15 +25,17 @@ var Info framework.Info = framework.Info{
 type CCMPyACTR struct {
 	framework.Framework
 	framework.WriterHelper
+
+	tmpPath string
+
 	model     *actr.Model
 	className string
-	tmpPath   string
 }
 
 // New simply creates a new CCMPyACTR instance and sets the tmp path.
-func New(cli *cli.Context) (c *CCMPyACTR, err error) {
+func New(ctx *cli.Context) (c *CCMPyACTR, err error) {
 
-	c = &CCMPyACTR{tmpPath: "tmp"}
+	c = &CCMPyACTR{tmpPath: ctx.Path("temp")}
 
 	return
 }

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -31,15 +31,17 @@ var Info framework.Info = framework.Info{
 type PyACTR struct {
 	framework.Framework
 	framework.WriterHelper
+
+	tmpPath string
+
 	model     *actr.Model
 	className string
-	tmpPath   string
 }
 
-// New simply creates a new PyACTR instance and sets the tmp path.
-func New(cli *cli.Context) (p *PyACTR, err error) {
+// New simply creates a new PyACTR instance and sets the tmp path from the context.
+func New(ctx *cli.Context) (p *PyACTR, err error) {
 
-	p = &PyACTR{tmpPath: "tmp"}
+	p = &PyACTR{tmpPath: ctx.Path("temp")}
 
 	return
 }

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -30,12 +30,12 @@ type VanillaACTR struct {
 	envPath   string
 }
 
-// New simply creates a new VanillaACTR instance and sets the tmp path.
-func New(cli *cli.Context) (v *VanillaACTR, err error) {
+// New simply creates a new VanillaACTR instance and sets some paths from the context.
+func New(ctx *cli.Context) (v *VanillaACTR, err error) {
 
 	v = &VanillaACTR{
-		tmpPath: "tmp",
-		envPath: cli.String("env"),
+		tmpPath: ctx.Path("temp"),
+		envPath: ctx.String("env"),
 	}
 
 	return


### PR DESCRIPTION
- replace "output" option with "temp" which applies to all modes
- change default path to "./gactar-temp"
- expand it to absolute path
- create it once at the top level
- set it in the context and use that for each framework