### PR TITLE
Add framework.ValidateModel()

### DIFF
--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asmaloney/gactar/actr"
 	"github.com/asmaloney/gactar/framework"
+	"github.com/asmaloney/gactar/issues"
 	"github.com/asmaloney/gactar/version"
 )
 
@@ -46,6 +47,11 @@ func (CCMPyACTR) Info() *framework.Info {
 
 func (c *CCMPyACTR) Initialize() (err error) {
 	return framework.Setup(&Info)
+}
+
+func (CCMPyACTR) ValidateModel(model *actr.Model) (log *issues.Log) {
+	log = issues.New()
+	return
 }
 
 // SetModel sets our model and saves the python class name we are going to use.

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -2,6 +2,8 @@ package framework
 
 import (
 	"github.com/asmaloney/gactar/actr"
+	"github.com/asmaloney/gactar/issues"
+
 	"github.com/asmaloney/gactar/util/container"
 )
 
@@ -35,6 +37,7 @@ type Framework interface {
 
 	Initialize() (err error)
 
+	ValidateModel(model *actr.Model) (log *issues.Log)
 	SetModel(model *actr.Model) (err error)
 	Model() (model *actr.Model)
 

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asmaloney/gactar/actr"
 	"github.com/asmaloney/gactar/framework"
+	"github.com/asmaloney/gactar/issues"
 	"github.com/asmaloney/gactar/version"
 	"github.com/urfave/cli/v2"
 )
@@ -47,6 +48,11 @@ func (VanillaACTR) Info() *framework.Info {
 
 func (v *VanillaACTR) Initialize() (err error) {
 	return framework.Setup(&Info)
+}
+
+func (VanillaACTR) ValidateModel(model *actr.Model) (log *issues.Log) {
+	log = issues.New()
+	return
 }
 
 func (v *VanillaACTR) SetModel(model *actr.Model) (err error) {

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -47,6 +47,11 @@ func (l Log) AllIssues() IssueList {
 	return l.issues
 }
 
+// HasIssues returns whether this log contains at least one entry.
+func (l Log) HasIssues() bool {
+	return len(l.issues) > 0
+}
+
 // HasError returns whether this log contains at least one error entry.
 func (l Log) HasError() bool {
 	return l.hasError

--- a/main.go
+++ b/main.go
@@ -287,6 +287,13 @@ func generateCode(frameworks framework.List, files []string, outputDir string, r
 
 		for file, model := range modelMap {
 			fmt.Printf("\t- generating code for %s\n", file)
+
+			log := f.ValidateModel(model)
+			fmt.Print(log)
+			if log.HasError() {
+				continue
+			}
+
 			err = f.SetModel(model)
 			if err != nil {
 				fmt.Println(err.Error())

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -183,6 +183,21 @@ func (s *Shell) cmdLoad(fileName string) (err error) {
 
 	}
 
+	for name, f := range s.actrFrameworks {
+		if !s.activeFrameworks[name] {
+			continue
+		}
+
+		log := f.ValidateModel(s.currentModel)
+		if log.HasIssues() {
+			fmt.Printf("== %s ==\n", f.Info().Name)
+			fmt.Print(log)
+			if log.HasError() {
+				continue
+			}
+		}
+	}
+
 	return
 }
 
@@ -202,6 +217,8 @@ func (s *Shell) cmdRun(initialGoal string) (err error) {
 		if !s.activeFrameworks[name] {
 			continue
 		}
+
+		fmt.Printf("== %s ==\n", f.Info().Name)
 
 		err = f.SetModel(s.currentModel)
 		if err != nil {


### PR DESCRIPTION
This lets us give warnings about unsupported features on a specific framework (e.g. pyactr's print statements).

Add the check to the cli & shell modes and output any issues.