### PR TITLE
Try to bring memory parameters more in line with each other

### DIFF
--- a/actr/decl_memory.go
+++ b/actr/decl_memory.go
@@ -6,13 +6,41 @@ type DeclMemory struct {
 
 	// Setting these kinds of parameters is going to be tricky.
 	// The way each framework handles timing is different.
-	// For example pyactr has an additional "rule_firing" setting that affects timing (see
-	// "Computational Cognitive Modeling and Linguistic Theory" section 8.4 pg. 201).
 
-	Latency   *float64 // latency factor
-	Threshold *float64 // retrieval threshold
-	MaxTime   *float64 // maximum time to run (in sim time, not real-time)
-	FinstSize *int     // finst == "fingers of instantiation"
+	// Latency
+	// See "Retrieval time" in "ACT-R 7.26 Reference Manual" pg. 293
+
+	// "latency_factor": latency factor (F)
+	// ccm: 0.05
+	// pyactr: 0.1
+	// vanilla: 1.0
+	LatencyFactor *float64
+
+	// "latency_exponent": latency exponent (f)
+	// ccm: (unsupported?)
+	// pyactr: 1.0
+	// vanilla: 1.0
+	LatencyExponent *float64
+
+	// "retrieval_threshold": retrieval threshold (τ)
+	// ccm: 0.0
+	// pyactr: 0.0
+	// vanilla: 0.0
+	RetrievalThreshold *float64
+
+	// finst ("fingers of instantiation")
+	// See "Declarative finsts" in "ACT-R 7.26 Reference Manual" pg. 293
+
+	// "finst_size": how many chunks are retained in memory
+	// ccm: 4
+	// pyactr: 0 (sic)
+	// vanilla: 4
+	FinstSize *int
+
+	// "finst_time": how long the finst lasts in memory
+	// ccm: 3.0
+	// pyactr: (unsupported?)
+	// vanilla: 3.0
 	FinstTime *float64
 }
 

--- a/amod/amod.go
+++ b/amod/amod.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/asmaloney/gactar/actr"
 	"github.com/asmaloney/gactar/issues"
+
+	"github.com/asmaloney/gactar/util/numbers"
 )
 
 var debugging bool = false
@@ -258,29 +260,39 @@ func addMemory(model *actr.Model, log *issueLog, mem []*field) {
 		value := field.Value
 
 		switch field.Key {
-		case "latency":
+		case "latency_factor":
 			if value.Number == nil {
-				log.errorT(value.Tokens, "memory latency '%s' must be a number", value.String())
+				log.errorT(value.Tokens, "memory latency_factor '%s' must be a number", value.String())
 				continue
 			}
 
-			model.Memory.Latency = value.Number
+			if *value.Number < 0 {
+				log.errorT(value.Tokens, "memory latency_factor '%s' must be greater than 0", numbers.Float64Str(*value.Number))
+				continue
+			}
 
-		case "threshold":
+			model.Memory.LatencyFactor = value.Number
+
+		case "latency_exponent":
 			if value.Number == nil {
-				log.errorT(value.Tokens, "memory threshold '%s' must be a number", value.String())
+				log.errorT(value.Tokens, "memory latency_exponent '%s' must be a number", value.String())
 				continue
 			}
 
-			model.Memory.Threshold = value.Number
-
-		case "max_time":
-			if field.Value.Number == nil {
-				log.errorT(value.Tokens, "memory max_time '%s' must be a number", value.String())
+			if *value.Number < 0 {
+				log.errorT(value.Tokens, "memory latency_exponent '%s' must be greater than 0", numbers.Float64Str(*value.Number))
 				continue
 			}
 
-			model.Memory.MaxTime = value.Number
+			model.Memory.LatencyExponent = value.Number
+
+		case "retrieval_threshold":
+			if value.Number == nil {
+				log.errorT(value.Tokens, "memory retrieval_threshold '%s' must be a number", value.String())
+				continue
+			}
+
+			model.Memory.RetrievalThreshold = value.Number
 
 		case "finst_size":
 			if value.Number == nil {
@@ -289,6 +301,11 @@ func addMemory(model *actr.Model, log *issueLog, mem []*field) {
 			}
 
 			size := int(*value.Number)
+			if size < 1 {
+				log.errorT(value.Tokens, "memory finst_size '%d' must be greater than 0", size)
+				continue
+			}
+
 			model.Memory.FinstSize = &size
 
 		case "finst_time":

--- a/amod/amod_test.go
+++ b/amod/amod_test.go
@@ -128,7 +128,7 @@ func Example_imaginalFields() {
 	==config==
 	modules {
 		imaginal { delay: 0.2 }
-		memory { latency: 0.5 }
+		memory { latency_factor: 0.5 }
 	}
 	==init==
 	==productions==`)

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -12,6 +12,8 @@ import (
 	"github.com/asmaloney/gactar/framework"
 	"github.com/asmaloney/gactar/issues"
 	"github.com/asmaloney/gactar/version"
+
+	"github.com/asmaloney/gactar/util/numbers"
 )
 
 var Info framework.Info = framework.Info{
@@ -51,6 +53,11 @@ func (c *CCMPyACTR) Initialize() (err error) {
 
 func (CCMPyACTR) ValidateModel(model *actr.Model) (log *issues.Log) {
 	log = issues.New()
+
+	if model.Memory.LatencyExponent != nil {
+		log.Warning(nil, "ccm does not support memory module's latency_exponent")
+	}
+
 	return
 }
 
@@ -153,16 +160,12 @@ func (c *CCMPyACTR) WriteModel(path string, initialBuffers framework.InitialBuff
 	memory := c.model.Memory
 	additionalInit := []string{}
 
-	if memory.Latency != nil {
-		additionalInit = append(additionalInit, fmt.Sprintf("latency=%s", framework.Float64Str(*memory.Latency)))
+	if memory.LatencyFactor != nil {
+		additionalInit = append(additionalInit, fmt.Sprintf("latency=%s", numbers.Float64Str(*memory.LatencyFactor)))
 	}
 
-	if memory.Threshold != nil {
-		additionalInit = append(additionalInit, fmt.Sprintf("threshold=%s", framework.Float64Str(*memory.Threshold)))
-	}
-
-	if memory.MaxTime != nil {
-		additionalInit = append(additionalInit, fmt.Sprintf("maximum_time=%s", framework.Float64Str(*memory.MaxTime)))
+	if memory.RetrievalThreshold != nil {
+		additionalInit = append(additionalInit, fmt.Sprintf("threshold=%s", numbers.Float64Str(*memory.RetrievalThreshold)))
 	}
 
 	if memory.FinstSize != nil {
@@ -170,7 +173,7 @@ func (c *CCMPyACTR) WriteModel(path string, initialBuffers framework.InitialBuff
 	}
 
 	if memory.FinstTime != nil {
-		additionalInit = append(additionalInit, fmt.Sprintf("finst_time=%s", framework.Float64Str(*memory.FinstTime)))
+		additionalInit = append(additionalInit, fmt.Sprintf("finst_time=%s", numbers.Float64Str(*memory.FinstTime)))
 	}
 
 	if len(additionalInit) > 0 {

--- a/framework/tools.go
+++ b/framework/tools.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/asmaloney/gactar/actr"
@@ -56,12 +55,6 @@ func ParseInitialBuffers(model *actr.Model, initialBuffers InitialBuffers) (pars
 	}
 
 	return
-}
-
-// Float64Str takes a float and returns a string of the minimal representation.
-// e.g. 2.5000 becomes "2.5"
-func Float64Str(f float64) string {
-	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 // RemoveTempFile removes the given file if it exists.

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -8,11 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/asmaloney/gactar/actr"
 	"github.com/asmaloney/gactar/framework"
 	"github.com/asmaloney/gactar/issues"
 	"github.com/asmaloney/gactar/version"
-	"github.com/urfave/cli/v2"
+
+	"github.com/asmaloney/gactar/util/numbers"
 )
 
 var Info framework.Info = framework.Info{
@@ -148,15 +151,30 @@ func (v *VanillaACTR) WriteModel(path string, initialBuffers framework.InitialBu
 
 	v.Writeln("(define-model %s\n", v.modelName)
 
-	v.Writeln("(sgp :esc t")
+	v.Writeln("(sgp")
+
+	// enable subsymbolic computations
+	v.Writeln("\t:esc t")
 
 	memory := v.model.Memory
-	if memory.Latency != nil {
-		v.Writeln("\t:lf %s", framework.Float64Str(*memory.Latency))
+	if memory.LatencyFactor != nil {
+		v.Writeln("\t:lf %s", numbers.Float64Str(*memory.LatencyFactor))
 	}
 
-	if memory.Threshold != nil {
-		v.Writeln("\t:rt %s", framework.Float64Str(*memory.Threshold))
+	if memory.LatencyExponent != nil {
+		v.Writeln("\t:le %s", numbers.Float64Str(*memory.LatencyExponent))
+	}
+
+	if memory.RetrievalThreshold != nil {
+		v.Writeln("\t:rt %s", numbers.Float64Str(*memory.RetrievalThreshold))
+	}
+
+	if memory.FinstSize != nil {
+		v.Writeln("\t:declarative-num-finsts %d", *memory.FinstSize)
+	}
+
+	if memory.FinstTime != nil {
+		v.Writeln("\t:declarative-finst-span %s", numbers.Float64Str(*memory.FinstTime))
 	}
 
 	switch v.model.LogLevel {
@@ -171,7 +189,7 @@ func (v *VanillaACTR) WriteModel(path string, initialBuffers framework.InitialBu
 	imaginal := v.model.GetImaginal()
 	if imaginal != nil {
 		v.Writeln("\t:do-not-harvest imaginal")
-		v.Writeln("\t:imaginal-delay %s", framework.Float64Str(imaginal.Delay))
+		v.Writeln("\t:imaginal-delay %s", numbers.Float64Str(imaginal.Delay))
 	}
 	v.Writeln(")\n")
 

--- a/util/numbers/numbers.go
+++ b/util/numbers/numbers.go
@@ -1,0 +1,10 @@
+// Package numbers provides utility functions for numbers
+package numbers
+
+import "strconv"
+
+// Float64Str takes a float and returns a string of the minimal representation.
+// e.g. 2.5000 becomes "2.5"
+func Float64Str(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}


### PR DESCRIPTION
- rename some options
- add latency exponent
- remove max_time
- add defaults for each framework in the comments
- add some range checks
- add per-framework warnings for unsupported options
- turn on pyactr's "subsymbolic" to be in line with vanilla