### PR TITLE
Handle virtual environment ourselves instead of requiring the "source" command

### DIFF
--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -40,7 +40,7 @@ func New(ctx *cli.Context) (v *VanillaACTR, err error) {
 
 	v = &VanillaACTR{
 		tmpPath: ctx.Path("temp"),
-		envPath: ctx.String("env"),
+		envPath: os.Getenv("VIRTUAL_ENV"),
 	}
 
 	return
@@ -94,12 +94,6 @@ func (v *VanillaACTR) Run(initialBuffers framework.InitialBuffers) (result *fram
 
 	// run it!
 	cmd := exec.Command(runFile)
-
-	// set SBCL_HOME so compiler works
-	sbclPath := fmt.Sprintf("%s/lib/sbcl", v.envPath)
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("SBCL_HOME=%s", sbclPath))
-
 	output, err := cmd.CombinedOutput()
 	output = removePreamble(output)
 	if err != nil {

--- a/util/filesystem/filesystem.go
+++ b/util/filesystem/filesystem.go
@@ -7,6 +7,11 @@ import (
 	"os/exec"
 )
 
+func DirExists(path string) bool {
+	stat, err := os.Stat(path)
+	return !os.IsNotExist(err) && stat.IsDir()
+}
+
 func CreateDir(path string) (err error) {
 	err = os.MkdirAll(path, 0750)
 	if err != nil && !os.IsExist(err) {


### PR DESCRIPTION
- no longer need to run "source ./env/bin/activate" to activate virtual environment
- sets PATH and VIRTUAL_ENV directly (which is essentially what the "activate" script does)
- use the "-env" option to point at a different environment (default is "./env")