### PR TITLE
Leave imaginal delay default up to frameworks

### DIFF
--- a/actr/modules/imaginal.go
+++ b/actr/modules/imaginal.go
@@ -6,15 +6,16 @@ import "github.com/asmaloney/gactar/actr/buffer"
 type Imaginal struct {
 	buffer.BufferInterface
 
-	Delay float64 // non-negative time (in seconds) and defaults to .2
+	// "delay": how long it takes a request to the buffer to complete (seconds)
+	// ccm: 0.2
+	// pyactr: 0.2
+	// vanilla: 0.2
+	Delay *float64
 }
 
 func NewImaginal() *Imaginal {
-	// This uses the defaults as per ACT-R docs:
-	// 	http://act-r.psy.cmu.edu/actr7.x/reference-manual.pdf page 276
 	return &Imaginal{
 		BufferInterface: buffer.Buffer{Name: "imaginal", MultipleInit: false},
-		Delay:           0.2,
 	}
 }
 
@@ -35,7 +36,7 @@ func (i *Imaginal) SetParam(param *Param) (err ParamError) {
 			return NumberMustBePositive
 		}
 
-		i.Delay = *value.Number
+		i.Delay = value.Number
 
 	default:
 		return UnrecognizedParam

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -249,7 +249,12 @@ func (p *PyACTR) WriteModel(path string, initialBuffers framework.InitialBuffers
 
 	imaginal := p.model.ImaginalModule()
 	if imaginal != nil {
-		p.Writeln(`imaginal = %s.set_goal(name="imaginal", delay=%s)`, p.className, numbers.Float64Str(imaginal.Delay))
+		p.Write(`imaginal = %s.set_goal(name="imaginal"`, p.className)
+		if imaginal.Delay != nil {
+			p.Write(", delay=%s", numbers.Float64Str(*imaginal.Delay))
+		}
+		p.Write(")")
+		p.Writeln("")
 		p.Writeln("")
 	}
 

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -193,7 +193,9 @@ func (v *VanillaACTR) WriteModel(path string, initialBuffers framework.InitialBu
 	imaginal := v.model.ImaginalModule()
 	if imaginal != nil {
 		v.Writeln("\t:do-not-harvest imaginal")
-		v.Writeln("\t:imaginal-delay %s", numbers.Float64Str(imaginal.Delay))
+		if imaginal.Delay != nil {
+			v.Writeln("\t:imaginal-delay %s", numbers.Float64Str(*imaginal.Delay))
+		}
 	}
 	v.Writeln(")\n")
 


### PR DESCRIPTION
(They are all 0.2 anyways.)