### PR TITLE
Replace SBCL compiler with Clozure Common Lisp (CCL) compiler

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,12 +149,9 @@ func setupVirtualEnvironment(ctx *cli.Context) (err error) {
 		return
 	}
 
-	os.Setenv("PATH", fmt.Sprintf("%s/bin:%s", envPath, os.Getenv("PATH")))
+	// add our env and our ccl paths
+	os.Setenv("PATH", fmt.Sprintf("%[1]s/bin:%[1]s/ccl:%[2]s", envPath, os.Getenv("PATH")))
 	os.Setenv("VIRTUAL_ENV", envPath)
-
-	// set SBCL_HOME so the sbcl compiler can find its stuff
-	sbclPath := fmt.Sprintf("%s/lib/sbcl", envPath)
-	os.Setenv("SBCL_HOME", sbclPath)
 
 	return
 }


### PR DESCRIPTION
It's smaller, easier to install & run, and might work on Windows without running an installer.