### PR TITLE
Add "when" clause to matches to reduce magical incantations

### DIFF
--- a/actr/production.go
+++ b/actr/production.go
@@ -1,6 +1,10 @@
 package actr
 
-import "github.com/asmaloney/gactar/actr/buffer"
+import (
+	"fmt"
+
+	"github.com/asmaloney/gactar/actr/buffer"
+)
 
 // Production stores information on how to match buffers and perform some operations.
 // It uses a small language to modify states upon successful matches.
@@ -18,9 +22,37 @@ type Production struct {
 
 // VarIndex is used to track which buffer slot a variable refers to
 type VarIndex struct {
-	Var      string
+	Var      *PatternVar
 	Buffer   buffer.BufferInterface
 	SlotName string
+}
+
+type Comparison int
+
+const (
+	Equal Comparison = iota
+	NotEqual
+)
+
+func (c Comparison) String() string {
+	switch c {
+	case Equal:
+		return "=="
+	case NotEqual:
+		return "!="
+	}
+
+	return "unknown"
+}
+
+type Constraint struct {
+	LHS        *string
+	Comparison Comparison
+	RHS        *Value
+}
+
+func (c Constraint) String() string {
+	return fmt.Sprintf("%s %s %s", *c.LHS, c.Comparison, c.RHS)
 }
 
 type Match struct {
@@ -47,6 +79,21 @@ type Value struct {
 	ID     *string
 	Str    *string
 	Number *string
+}
+
+func (v Value) String() string {
+	switch {
+	case v.Var != nil:
+		return *v.Var
+	case v.ID != nil:
+		return *v.ID
+	case v.Str != nil:
+		return *v.Str
+	case v.Number != nil:
+		return *v.Number
+	}
+
+	return "unknown"
 }
 
 // PrintStatement outputs the string, id, or number to stdout.

--- a/amod/amod_productions_test.go
+++ b/amod/amod_productions_test.go
@@ -19,6 +19,73 @@ func Example_production() {
 	// Output:
 }
 
+func Example_productionWhenClause() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match {
+			goal [foo: ?blat] when ( ?blat == "foo" )
+		}
+		do {
+			print ?blat
+			stop
+		}
+	}`)
+
+	// Output:
+}
+
+func Example_productionWhenClauseNegatedAndConstrained() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match {
+			goal [foo: !?blat]
+				when ( ?blat == "foo" )
+		}
+		do {
+			print ?blat
+			stop
+		}
+	}`)
+
+	// Output:
+	// ERROR: cannot further constrain a negated variable '?blat' (line 11, col 11)
+}
+
+func Example_productionWhenClauseComparisonToSelf() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match {
+			goal [foo: ?blat]
+				when ( ?blat == ?blat )
+		}
+		do {
+			print ?blat
+			stop
+		}
+	}`)
+
+	// Output:
+	// ERROR: cannot compare a variable to itself '?blat' (line 11, col 20)
+}
+
 func Example_productionWildcard() {
 	generateToStdout(`
 	~~ model ~~
@@ -291,23 +358,6 @@ func Example_productionSetStatementNonVar2() {
 
 	// Output:
 	// ERROR: set statement variable '?ding' not found in matches for production 'start' (line 10, col 25)
-}
-
-func Example_productionSetStatementCompoundVar() {
-	generateToStdout(`
-	~~ model ~~
-	name: Test
-	~~ config ~~
-	chunks { [foo: thing] }
-	~~ init ~~
-	~~ productions ~~
-	start {
-		match { goal [foo: ?ding] }
-		do { set goal to [foo: ?ding!5] }
-	}`)
-
-	// Output:
-	// ERROR: cannot set 'goal.thing' to compound var in production 'start' (line 10, col 25)
 }
 
 func Example_productionSetStatementAssignNonPattern() {

--- a/amod/lex.go
+++ b/amod/lex.go
@@ -129,6 +129,7 @@ const (
 )
 
 var keywords []string = []string{
+	"and",
 	"chunks",
 	"clear",
 	"description",
@@ -144,6 +145,7 @@ var keywords []string = []string{
 	"set",
 	"stop",
 	"to",
+	"when",
 }
 
 // Symbols provides a mapping from participle strings to our lexemes

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -134,21 +134,15 @@ type initSection struct {
 	Tokens []lexer.Token
 }
 
-type patternSlotItem struct {
-	Not      bool    `parser:"(@('!':Char)?"`
+type patternSlot struct {
+	Space1   string  `parser:"@PatternSpace?"`
+	Not      bool    `parser:"((@('!':Char)?"`
 	Nil      *bool   `parser:"( @('nil':Keyword)"`
 	ID       *string `parser:"| @Ident"`
 	Num      *string `parser:"| @Number"` // we don't need to treat this as a number anywhere, so keep as a string
 	Var      *string `parser:"| @PatternVar ))"`
-	Wildcard *string `parser:"| @PatternWildcard"`
-
-	Tokens []lexer.Token
-}
-
-type patternSlot struct {
-	Space1 string             `parser:"@PatternSpace?"`
-	Items  []*patternSlotItem `parser:"@@+"`
-	Space2 string             `parser:"@PatternSpace?"`
+	Wildcard *string `parser:"| @PatternWildcard)"`
+	Space2   string  `parser:"@PatternSpace?"`
 
 	Tokens []lexer.Token
 }
@@ -162,9 +156,34 @@ type pattern struct {
 	Tokens []lexer.Token
 }
 
+type comparisonOperator struct {
+	Equal    *string `parser:"( @Equality"`
+	NotEqual *string `parser:"| @Inequality )"`
+
+	Tokens []lexer.Token
+}
+
+type whenExpression struct {
+	OpenParen  string              `parser:"'('"` // not used - must be set for parse
+	LHS        string              `parser:"@PatternVar"`
+	Comparison *comparisonOperator `parser:"@@"`
+	RHS        *arg                `parser:"@@"`
+	CloseParen string              `parser:"')'"` // not used - must be set for parse
+
+	Tokens []lexer.Token
+}
+
+type whenClause struct {
+	When        string             `parser:"'when':Keyword"`
+	Expressions *[]*whenExpression `parser:"@@ ('and' @@)*"`
+
+	Tokens []lexer.Token
+}
+
 type matchItem struct {
-	Name    string   `parser:"@Ident"`
-	Pattern *pattern `parser:"@@"`
+	Name    string      `parser:"@Ident"`
+	Pattern *pattern    `parser:"@@"`
+	When    *whenClause `parser:"@@?"`
 
 	Tokens []lexer.Token
 }

--- a/examples/addition.amod
+++ b/examples/addition.amod
@@ -81,7 +81,7 @@ terminateAddition {
 
 incrementSum {
     match {
-        goal [add: * ?num2 ?count!?num2 ?sum]
+        goal [add: * ?num2 ?count ?sum] when (?count != ?num2)
         retrieval [count: ?sum ?next]
     }
     do {

--- a/examples/semantic.amod
+++ b/examples/semantic.amod
@@ -76,7 +76,7 @@ directVerify {
 chainCategory {
     match {
         goal [isMember: ?obj1 ?cat pending]
-        retrieval [property: ?obj1 category ?obj2!?cat]
+        retrieval [property: ?obj1 category ?obj2] when (?obj2 != ?cat)
     }
     do {
         set goal.object to ?obj2

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -445,29 +445,40 @@ func (c CCMPyACTR) outputMatch(match *actr.Match) {
 	}
 }
 
-func patternSlotString(patternSlot *actr.PatternSlot) string {
+func patternSlotString(slot *actr.PatternSlot) string {
 	var str string
 
-	for _, item := range patternSlot.Items {
-		if item.Negated {
-			str += "!"
-		}
+	if slot.Negated {
+		str += "!"
+	}
 
-		switch {
-		case item.Wildcard:
-			str += "?"
+	switch {
+	case slot.Wildcard:
+		str += "?"
 
-		case item.Nil:
-			str += "None"
+	case slot.Nil:
+		str += "None"
 
-		case item.ID != nil:
-			str += *item.ID
+	case slot.ID != nil:
+		str += *slot.ID
 
-		case item.Var != nil:
-			str += *item.Var
+	case slot.Var != nil:
+		str += *slot.Var.Name
 
-		case item.Num != nil:
-			str += *item.Num
+	case slot.Num != nil:
+		str += *slot.Num
+	}
+
+	// Check for constraints on a var and output them
+	if slot.Var != nil {
+		if len(slot.Var.Constraints) > 0 {
+			for _, constraint := range slot.Var.Constraints {
+				if constraint.Comparison == actr.NotEqual {
+					str += "!"
+				}
+
+				str += constraint.RHS.String()
+			}
 		}
 	}
 

--- a/modes/web/gactar-web/src/codemirror/amod.ts
+++ b/modes/web/gactar-web/src/codemirror/amod.ts
@@ -13,6 +13,7 @@ CodeMirror.defineMode('amod', function () {
   const variable_regex = /[?][a-zA-Z0-9_]*/
 
   const keywords = {
+    and: true,
     authors: true,
     chunks: true,
     clear: true,
@@ -28,6 +29,7 @@ CodeMirror.defineMode('amod', function () {
     set: true,
     stop: true,
     to: true,
+    when: true,
     true: true,
     false: true, // ;-)
     nil: true,


### PR DESCRIPTION
```
    match {
        goal [add: * ?num2 ?count!?num2 ?sum]
        retrieval [count: ?sum ?next]
    }
```

becomes:

```
    match {
        goal [add: * ?num2 ?count ?sum] when (?count != ?num2)
        retrieval [count: ?sum ?next]
    }
```

This sets us up for #187 if I can figure out how to implement the other constraints in ccm.