### PR TITLE
{web} Cleanup component properties by passing FrameworkInfo

### DIFF
--- a/modes/web/gactar-web/src/App.vue
+++ b/modes/web/gactar-web/src/App.vue
@@ -22,17 +22,15 @@
           <amod-code-tab @codeChange="codeChange" @showError="showError" />
 
           <template v-for="tab in tabs">
-            <code-tab
+            <framework-code-tab
               v-if="tab.displayed"
-              :key="tab.id"
-              :value="tab.id"
-              :framework="tab.id"
-              :mode="tab.mode"
-              :file-extension="tab.fileExtension"
+              :key="tab.framework.name"
+              :value="tab.framework.name"
+              :framework="tab.framework"
               :model-name="tab.modelName"
-              :code="code[tab.id]"
+              :code="code[tab.framework.name]"
             >
-            </code-tab>
+            </framework-code-tab>
           </template>
         </b-tabs>
       </div>
@@ -45,13 +43,13 @@
               v-model="selectedFrameworks"
               type="is-info"
               size="is-small"
-              :native-value="tab.id"
-              :key="tab.id"
+              :native-value="tab.framework.name"
+              :key="tab.framework.name"
               expanded
               class="ml-1 mr-1"
               @input="frameworkChanged"
             >
-              <span>{{ tab.id }}</span>
+              <span>{{ tab.framework.name }}</span>
             </b-checkbox-button>
           </b-field>
         </div>
@@ -95,12 +93,11 @@ import api, {
 import { commentString, issuesToArray } from './utils'
 
 import AmodCodeTab from './components/AmodCodeTab.vue'
-import CodeTab from './components/CodeTab.vue'
+import FrameworkCodeTab from './components/FrameworkCodeTab.vue'
 
 interface Tab {
-  id: string
-  mode: string
-  fileExtension: string
+  framework: FrameworkInfo
+
   modelName: string
   displayed: boolean
 }
@@ -126,7 +123,7 @@ interface Data {
 const selectedFrameworksStorageName = 'gactar.selected-frameworks'
 
 export default Vue.extend({
-  components: { AmodCodeTab, CodeTab },
+  components: { AmodCodeTab, FrameworkCodeTab },
 
   data(): Data {
     return {
@@ -181,7 +178,7 @@ export default Vue.extend({
 
     hideTabsNotInUse() {
       this.baseTabs.forEach((tab: Tab) => {
-        if (!this.selectedFrameworks.includes(tab.id)) {
+        if (!this.selectedFrameworks.includes(tab.framework.name)) {
           tab.displayed = false
         }
       })
@@ -194,9 +191,7 @@ export default Vue.extend({
           list.forEach((info: FrameworkInfo) => {
             // create tab info for each language present on the server
             const tab: Tab = {
-              id: info.name,
-              mode: info.language,
-              fileExtension: info.fileExtension,
+              framework: info,
               modelName: '',
               displayed: false,
             }
@@ -298,7 +293,9 @@ export default Vue.extend({
           )
         }
 
-        const index = this.tabs.findIndex((obj: Tab) => obj.id == framework)
+        const index = this.tabs.findIndex(
+          (obj: Tab) => obj.framework.name == framework
+        )
         if (index != -1) {
           this.tabs[index].modelName = result.modelName
 

--- a/modes/web/gactar-web/src/components/AmodCodeTab.vue
+++ b/modes/web/gactar-web/src/components/AmodCodeTab.vue
@@ -46,7 +46,7 @@
       ref="code-editor"
       :amod-code="amodCode"
       mode="amod"
-      framework="amod"
+      editorID="amod"
       @editorCodeChange="editorCodeChange"
     />
   </b-tab-item>

--- a/modes/web/gactar-web/src/components/CodeMirror.vue
+++ b/modes/web/gactar-web/src/components/CodeMirror.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
       type: Boolean,
       default: false,
     },
-    framework: {
+    editorID: {
       type: String,
       required: true,
     },
@@ -49,7 +49,7 @@ export default Vue.extend({
   data(): Data {
     return {
       editor: null,
-      id: 'id-' + this.framework,
+      id: 'id-' + this.editorID,
       code: this.amodCode,
     }
   },

--- a/modes/web/gactar-web/src/components/FrameworkCodeTab.vue
+++ b/modes/web/gactar-web/src/components/FrameworkCodeTab.vue
@@ -1,14 +1,14 @@
 <template>
-  <b-tab-item class="code-tab" :label="framework">
+  <b-tab-item class="code-tab" :label="framework.name">
     <div class="columns buttons">
       <div class="column">
-        <strong>{{ defaultFileName }}.{{ fileExtension }}</strong> (generated
-        code)
+        <strong>{{ defaultFileName }}.{{ framework.fileExtension }}</strong>
+        (generated for {{ framework.executableName }})
         <b-field class="is-pulled-right">
           <save-button
             :code="code"
             :default-name="defaultFileName"
-            :file-extension="fileExtension"
+            :file-extension="framework.fileExtension"
           />
         </b-field>
       </div>
@@ -18,15 +18,17 @@
       :key="count"
       :ref="refName"
       :amod-code="code"
-      :mode="mode"
-      :framework="framework"
+      :mode="framework.language"
+      :editorID="framework.name"
       :read-only="true"
     />
   </b-tab-item>
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { PropType } from 'vue'
+
+import { FrameworkInfo } from '@/api'
 
 import CodeMirror from './CodeMirror.vue'
 import SaveButton from './SaveButton.vue'
@@ -46,16 +48,8 @@ export default Vue.extend({
       type: String,
       required: true,
     },
-    mode: {
-      type: String,
-      required: true,
-    },
-    fileExtension: {
-      type: String,
-      required: true,
-    },
     framework: {
-      type: String,
+      type: Object as PropType<FrameworkInfo>,
       required: true,
     },
     modelName: {
@@ -68,8 +62,8 @@ export default Vue.extend({
     return {
       fileToLoad: null,
 
-      accept: '.' + this.mode + ',text/plain',
-      refName: 'code-editor-' + this.mode,
+      accept: '.' + this.framework.language + ',text/plain',
+      refName: 'code-editor-' + this.framework.language,
 
       // This is used to prevent caching of the code-mirror data.
       // See https://stackoverflow.com/questions/48400302/vue-js-not-updating-props-in-child-when-parent-component-is-changing-the-propert
@@ -79,7 +73,7 @@ export default Vue.extend({
 
   computed: {
     defaultFileName(): string {
-      return this.framework + '_' + this.modelName
+      return this.framework.name + '_' + this.modelName
     },
   },
 


### PR DESCRIPTION
Also rename "CodeTab" to "FrameworkCodeTab" for clarity.