### PR TITLE
Fix command line output so gactar version is output first

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,6 +154,10 @@ func main() {
 			&cli.IntFlag{Name: "port", Aliases: []string{"p"}, Category: "Mode: Web", Value: defaultPort, Usage: "port to run the web server on"},
 		},
 		Action: func(c *cli.Context) error {
+			// Override cli's version printing so we ensure it comes first
+			cli.VersionPrinter = func(c *cli.Context) {}
+			fmt.Printf("%s version %s\n", c.App.Name, c.App.Version)
+
 			if c.Bool("debug") {
 				amod.SetDebug(true)
 			}

--- a/modes/defaultmode/defaultmode.go
+++ b/modes/defaultmode/defaultmode.go
@@ -102,6 +102,7 @@ func generateCode(frameworks framework.List, files []string, outputDir string, r
 	}
 
 	for _, f := range frameworks {
+		fmt.Printf(" %s\n", f.Info().Name)
 		for file, model := range modelMap {
 			fmt.Printf("\t- generating code for %s\n", file)
 


### PR DESCRIPTION
Also add in framework names since the init is happening at a different time now.