### PR TITLE
Update "participle" parser package (now uses generics)

### DIFF
--- a/amod/amod.go
+++ b/amod/amod.go
@@ -118,13 +118,15 @@ func ParseChunk(model *actr.Model, chunk string) (*actr.Pattern, error) {
 		chunk += "]"
 	}
 
-	var p pattern
-
-	r := strings.NewReader(chunk)
-
 	log := newLog()
 
-	err := patternParser.Parse("", r, &p)
+	patternParser, err := participle.ParserForProduction[pattern](amodParser)
+	if err != nil {
+		err = &ErrParseChunk{Message: err.Error()}
+		return nil, err
+	}
+
+	p, err := patternParser.ParseString("", chunk)
 	if err != nil {
 		pErr, ok := err.(participle.Error)
 		if ok {
@@ -134,13 +136,13 @@ func ParseChunk(model *actr.Model, chunk string) (*actr.Pattern, error) {
 		return nil, err
 	}
 
-	err = validatePattern(model, log, &p)
+	err = validatePattern(model, log, p)
 	if err != nil {
 		err = &ErrParseChunk{Message: log.FirstEntry()}
 		return nil, err
 	}
 
-	return createChunkPattern(model, log, &p)
+	return createChunkPattern(model, log, p)
 }
 
 // generateModel runs through the parsed structures and creates an actr.Model from them

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -304,28 +304,19 @@ type productionSection struct {
 	Tokens []lexer.Token
 }
 
-var amodParser = participle.MustBuild(&amodFile{},
+var amodParser = participle.MustBuild[amodFile](
 	participle.Lexer(LexerDefinition),
 	participle.Elide("Comment", "Whitespace"),
 	participle.Unquote(),
 )
 
-var patternParser = participle.MustBuild(&pattern{},
-	participle.Lexer(LexerDefinition),
-	participle.Elide("Comment", "Whitespace"),
-	participle.Unquote(),
-)
-
-func parse(r io.Reader) (*amodFile, error) {
-	var amod amodFile
-
-	err := amodParser.Parse("", r, &amod)
-
+func parse(r io.Reader) (amod *amodFile, err error) {
+	amod, err = amodParser.Parse("", r)
 	if err != nil {
 		return nil, err
 	}
 
-	return &amod, nil
+	return
 }
 
 func parseFile(filename string) (*amodFile, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/asmaloney/gactar
 go 1.18
 
 require (
-	github.com/alecthomas/participle/v2 v2.0.0-beta.1
+	github.com/alecthomas/participle/v2 v2.0.0-beta.2
 	github.com/kylelemons/godebug v1.1.0
 	github.com/urfave/cli/v2 v2.10.3
 	github.com/vearutop/statigz v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/alecthomas/assert/v2 v2.0.3 h1:WKqJODfOiQG0nEJKFKzDIG3E29CN2/4zR9XGJzKIkbg=
-github.com/alecthomas/participle/v2 v2.0.0-beta.1 h1:qA1IALv09wFD4fQ2anV6MCl1BIInd+Dm+ksI6ES4kfs=
-github.com/alecthomas/participle/v2 v2.0.0-beta.1/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
+github.com/alecthomas/participle/v2 v2.0.0-beta.2 h1:iCENLBxIYQvtQdkenzAKgXpP72fudHI+j4RFPfaiKYk=
+github.com/alecthomas/participle/v2 v2.0.0-beta.2/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=

--- a/vendor/github.com/alecthomas/participle/v2/.golangci.yml
+++ b/vendor/github.com/alecthomas/participle/v2/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - errname
     - nilnil
     - maintidx
+    - unused # Does not work with type parameters
 
 linters-settings:
   govet:

--- a/vendor/github.com/alecthomas/participle/v2/TUTORIAL.md
+++ b/vendor/github.com/alecthomas/participle/v2/TUTORIAL.md
@@ -252,21 +252,20 @@ To parse with this grammar we first construct the parser (we'll use the
 default lexer for now):
 
 ```go
-parser, err := participle.Build(&INI{})
+parser, err := participle.Build[INI]()
 ```
 
-Then create a root node and parse into it with `parser.Parse{,String,Bytes}()`:
+Then parse a new INI file with `parser.Parse{,String,Bytes}()`:
 
 ```go
-ini := &INI{}
-err = parser.ParseString("", `
+ini, err := parser.ParseString("", `
 age = 21
 name = "Bob Smith"
 
 [address]
 city = "Beverly Hills"
 postal_code = 90210
-`, ini)
+`)
 ```
 
 You can find the full example [here](_examples/ini/main.go), alongside

--- a/vendor/github.com/alecthomas/participle/v2/ebnf.go
+++ b/vendor/github.com/alecthomas/participle/v2/ebnf.go
@@ -8,8 +8,8 @@ import (
 // String returns the EBNF for the grammar.
 //
 // Productions are always upper cased. Lexer tokens are always lower case.
-func (p *Parser) String() string {
-	return ebnf(p.root)
+func (p *Parser[G]) String() string {
+	return ebnf(p.typeNodes[p.rootType])
 }
 
 type ebnfp struct {

--- a/vendor/github.com/alecthomas/participle/v2/lexer/codegen.go
+++ b/vendor/github.com/alecthomas/participle/v2/lexer/codegen.go
@@ -43,10 +43,13 @@ import (
 	"io"
 	"strings"
 	"unicode/utf8"
+	"regexp/syntax"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 )
+
+var _ syntax.Op
 
 var Lexer lexer.Definition = definitionImpl{}
 

--- a/vendor/github.com/alecthomas/participle/v2/map.go
+++ b/vendor/github.com/alecthomas/participle/v2/map.go
@@ -22,7 +22,7 @@ type Mapper func(token lexer.Token) (lexer.Token, error)
 //
 // "symbols" specifies the token symbols that the Mapper will be applied to. If empty, all tokens will be mapped.
 func Map(mapper Mapper, symbols ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.mappers = append(p.mappers, mapperByToken{
 			mapper:  mapper,
 			symbols: symbols,
@@ -73,7 +73,7 @@ func Upper(types ...string) Option {
 
 // Elide drops tokens of the specified types.
 func Elide(types ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.elide = append(p.elide, types...)
 		return nil
 	}

--- a/vendor/github.com/alecthomas/participle/v2/options.go
+++ b/vendor/github.com/alecthomas/participle/v2/options.go
@@ -14,11 +14,11 @@ import (
 const MaxLookahead = 99999
 
 // An Option to modify the behaviour of the Parser.
-type Option func(p *Parser) error
+type Option func(p *parserOptions) error
 
 // Lexer is an Option that sets the lexer to use with the given grammar.
 func Lexer(def lexer.Definition) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.lex = def
 		return nil
 	}
@@ -39,7 +39,7 @@ func Lexer(def lexer.Definition) Option {
 // Using infinite lookahead can be useful for testing, or for parsing especially
 // ambiguous grammars. Use at your own risk!
 func UseLookahead(n int) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		p.useLookahead = n
 		return nil
 	}
@@ -50,7 +50,7 @@ func UseLookahead(n int) Option {
 // Note that the lexer itself will also have to be case-insensitive; this option
 // just controls whether literals in the grammar are matched case insensitively.
 func CaseInsensitive(tokens ...string) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		for _, token := range tokens {
 			p.caseInsensitive[token] = true
 		}
@@ -70,7 +70,7 @@ func CaseInsensitive(tokens ...string) Option {
 // This can be useful if you want to parse a DSL within the larger grammar, or if you want
 // to implement an optimized parsing scheme for some portion of the grammar.
 func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		parseFnVal := reflect.ValueOf(parseFn)
 		parseFnType := parseFnVal.Type()
 		if parseFnType.Out(0).Kind() != reflect.Interface {
@@ -95,7 +95,7 @@ func ParseTypeWith[T any](parseFn func(*lexer.PeekingLexer) (T, error)) Option {
 // and the source string is "AB", then the parser will only match A, and will not
 // try to parse the second member at all.
 func Union[T any](members ...T) Option {
-	return func(p *Parser) error {
+	return func(p *parserOptions) error {
 		unionType := reflect.TypeOf((*T)(nil)).Elem()
 		if unionType.Kind() != reflect.Interface {
 			return fmt.Errorf("Union: union type must be an interface (got %s)", unionType)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/alecthomas/participle/v2 v2.0.0-beta.1
+# github.com/alecthomas/participle/v2 v2.0.0-beta.2
 ## explicit; go 1.18
 github.com/alecthomas/participle/v2
 github.com/alecthomas/participle/v2/lexer


### PR DESCRIPTION
Eliminates the need for a second parser just for parsing the user-specified goal.