### PR TITLE
Use "mismatch_penalty" to turn on partial matching

### DIFF
--- a/actr/modules/declarative_memory.go
+++ b/actr/modules/declarative_memory.go
@@ -84,6 +84,13 @@ type DeclarativeMemory struct {
 	// 	pyactr (instantaneous_noise)
 	// 	vanilla (:ans)
 	InstantaneousNoise *float64
+
+	// "mismatch_penalty": turns on partial matching and sets the penalty in the activation equation to this
+	// (there are no defaults since setting it activates the capability)
+	// 	ccm (Partial class)
+	// 	pyactr (partial_matching & mismatch_penalty)
+	// 	vanilla (:mp)
+	MismatchPenalty *float64
 }
 
 func NewDeclarativeMemory() *DeclarativeMemory {
@@ -185,6 +192,13 @@ func (d *DeclarativeMemory) SetParam(param *params.Param) (err error) {
 		}
 
 		d.InstantaneousNoise = value.Number
+
+	case "mismatch_penalty":
+		if value.Number == nil {
+			return params.ErrInvalidType{ExpectedType: params.Number}
+		}
+
+		d.MismatchPenalty = value.Number
 
 	default:
 		return params.ErrUnrecognizedParam

--- a/actr/modules/procedural.go
+++ b/actr/modules/procedural.go
@@ -12,13 +12,6 @@ type Procedural struct {
 	// 	pyactr (rule_firing): 0.05
 	// 	vanilla (:dat): 0.05
 	DefaultActionTime *float64
-
-	// "partial_matching": turn on partial matching of buffers in productions
-	// (there are no defaults since setting it activates the capability)
-	// 	ccm (Partial class)
-	// 	pyactr (partial_matching)
-	// 	vanilla (:ppm)
-	PartialMatching bool
 }
 
 func NewProcedural() *Procedural {
@@ -41,14 +34,6 @@ func (p *Procedural) SetParam(param *params.Param) (err error) {
 		}
 
 		p.DefaultActionTime = value.Number
-
-	case "partial_matching":
-		boolVal, err := value.AsBool()
-		if err != nil {
-			return err
-		}
-
-		p.PartialMatching = boolVal
 
 	default:
 		return params.ErrUnrecognizedParam

--- a/amod/amod_config_test.go
+++ b/amod/amod_config_test.go
@@ -195,10 +195,10 @@ func Example_modulesAll() {
 			decay: 0.6
 			max_spread_strength: 0.9
 			instantaneous_noise: 0.5
+			mismatch_penalty: 1.0
 		}
 		procedural {
 			default_action_time: 0.06
-			partial_matching: true
 		}
 	}
 	~~ init ~~

--- a/amod/amod_init_test.go
+++ b/amod/amod_init_test.go
@@ -237,8 +237,8 @@ func Example_initializerPartialSimilarities() {
 	name: Test
 	~~ config ~~
 	modules {
-		procedural {
-			partial_matching: true
+		memory {
+			mismatch_penalty: 1.0
 		}
 	}
 	chunks {

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -227,14 +227,14 @@ func (c *CCMPyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code 
 		c.Writeln("    DMNoise(%s, noise=%s)", memory.ModuleName(), numbers.Float64Str(*memory.InstantaneousNoise))
 		c.Writeln("")
 	}
-
-	procedural := c.model.Procedural
-	// Turn on Partial if we have set "partial_matching"
-	if procedural.PartialMatching {
-		c.Writeln("    partial = Partial(%[1]s)", memory.ModuleName())
+	// Turn on Partial if we have set "mismatch_penalty"
+	if memory.MismatchPenalty != nil {
+		c.Writeln("    partial = Partial(%[1]s, limit=%s)", memory.ModuleName(), numbers.Float64Str(*memory.MismatchPenalty))
 		c.writeSimilarities("partial")
 		c.Writeln("")
 	}
+
+	procedural := c.model.Procedural
 
 	if procedural.DefaultActionTime != nil {
 		c.Writeln("    production_time = %s", numbers.Float64Str(*procedural.DefaultActionTime))
@@ -321,7 +321,6 @@ func (c CCMPyACTR) writeAuthors() {
 
 func (c CCMPyACTR) writeImports() {
 	memory := c.model.Memory
-	procedural := c.model.Procedural
 
 	imports := []string{"ACTR", "Buffer", "Memory"}
 
@@ -341,7 +340,7 @@ func (c CCMPyACTR) writeImports() {
 		additionalImports = append(additionalImports, "DMNoise")
 	}
 
-	if procedural.PartialMatching {
+	if memory.MismatchPenalty != nil {
 		additionalImports = append(additionalImports, "Partial")
 	}
 

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -218,13 +218,13 @@ func (p *PyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code []b
 		p.Writeln("    instantaneous_noise=%s,", numbers.Float64Str(*memory.InstantaneousNoise))
 	}
 
+	if memory.MismatchPenalty != nil {
+		p.Writeln("    partial_matching=True, mismatch_penalty=%s,", numbers.Float64Str(*memory.MismatchPenalty))
+	}
+
 	procedural := p.model.Procedural
 	if procedural.DefaultActionTime != nil {
 		p.Writeln("    rule_firing=%s,", numbers.Float64Str(*procedural.DefaultActionTime))
-	}
-
-	if procedural.PartialMatching {
-		p.Writeln("    partial_matching=True,")
 	}
 
 	if p.model.TraceActivations {

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -239,13 +239,13 @@ func (v *VanillaACTR) GenerateCode(initialBuffers framework.InitialBuffers) (cod
 		v.Writeln("\t:ans %s", numbers.Float64Str(*memory.InstantaneousNoise))
 	}
 
+	if memory.MismatchPenalty != nil {
+		v.Writeln("\t:mp %s", numbers.Float64Str(*memory.MismatchPenalty))
+	}
+
 	procedural := v.model.Procedural
 	if procedural.DefaultActionTime != nil {
 		v.Writeln("\t:dat %s", numbers.Float64Str(*procedural.DefaultActionTime))
-	}
-
-	if procedural.PartialMatching {
-		v.Writeln("\t:ppm 1")
 	}
 
 	switch v.model.LogLevel {


### PR DESCRIPTION
Also remove procedural "partial_matching" option since it can't be applied to all frameworks.

See #256