### PR TITLE
Add "--no-colour" as alias for "--no-color" command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - {shell} Interactive mode now recognizes up a & down arrow keys to navigate history. ([#287](https://github.com/asmaloney/gactar/pull/287))
 
 - Command line output now uses colour. ([#284](https://github.com/asmaloney/gactar/pull/284))
-  - May be turned off using a command-line option (`--no-color`) or by setting the `NO_COLOR` environment variable.
+  - May be turned off using a command-line option (`--no-colour` or `--no-color`) or by setting the `NO_COLOR` environment variable.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ gactar [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--interactive, -i**: run an interactive shell
 
+**--no-color, --no-colour**: do not use colour output on command line
+
 **--port, -p** [number]: port to run the web server on (default: `8181`)
 
 **--run, -r**: run the models after generating the code

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jwalton/gchalk"
 	"github.com/urfave/cli/v2"
 
 	"github.com/asmaloney/gactar/amod"
@@ -153,7 +154,18 @@ func main() {
 			},
 
 			// Colour
-			&cli.BoolFlag{Name: "no-color", Category: "Global", Usage: "do not use colour output on command line"},
+			&cli.BoolFlag{
+				Name:     "no-color",
+				Aliases:  []string{"no-colour"},
+				Category: "Global",
+				Usage:    "do not use colour output on command line",
+				Action: func(c *cli.Context, noColour bool) error {
+					if noColour {
+						gchalk.SetLevel(gchalk.LevelNone)
+					}
+					return nil
+				},
+			},
 
 			// CLI mode
 			&cli.BoolFlag{Name: "run", Aliases: []string{"r"}, Category: "Mode: CLI", Usage: "run the models after generating the code"},


### PR DESCRIPTION
Also accepts single-dash versions: `-no-colour` & `-no-color`