### PR TITLE
When generating unnamed dm inits, instead of fact_*, use the chunk name (e.g. count_0)

### DIFF
--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -374,7 +374,7 @@ func (v VanillaACTR) writeInitializers(goal *actr.Pattern) {
 			if init.ChunkName != nil {
 				v.Writeln(" (%s", *init.ChunkName)
 			} else {
-				v.Writeln(" (fact_%d", factNum)
+				v.Writeln(" (%s_%d", init.Pattern.Chunk.TypeName, factNum)
 				factNum++
 			}
 


### PR DESCRIPTION
These don't affect anything, but the term "fact" can be problematic