### PR TITLE
Split states into buffer states and module states

### DIFF
--- a/actr/buffer/buffer.go
+++ b/actr/buffer/buffer.go
@@ -2,24 +2,17 @@
 package buffer
 
 import (
-	"fmt"
-	"sort"
 	"strings"
 
 	"golang.org/x/exp/slices"
 )
 
-// validBufferStates is a list of the valid buffer states to use with the _status chunk
+// validStates is a list of valid buffer states to use when matching
 // TODO: needs review and correction
 // See: https://github.com/asmaloney/gactar/discussions/221
-var validBufferStates = map[string]bool{
-	// buffer
-	"empty": true,
-	"full":  true,
-
-	// state
-	"busy":  true,
-	"error": true,
+var validStates = []string{
+	"empty",
+	"full",
 }
 
 type Buffer struct {
@@ -98,19 +91,12 @@ func (b List) Lookup(name string) Interface {
 	return nil
 }
 
-// IsValidBufferState checks if 'state' is a valid buffer state.
-func IsValidBufferState(state string) bool {
-	v, ok := validBufferStates[state]
-	return v && ok
+// IsValidState checks if 'state' is a valid buffer state.
+func IsValidState(state string) bool {
+	return slices.Contains(validStates, state)
 }
 
-// ValidBufferStatesStr returns a list of (sorted) valid buffer states. Used for error output.
-func ValidBufferStatesStr() string {
-	keys := make([]string, 0, len(validBufferStates))
-	for k := range validBufferStates {
-		keys = append(keys, fmt.Sprintf("'%s'", k))
-	}
-
-	sort.Strings(keys)
-	return strings.Join(keys, ", ")
+// ValidStatesStr returns a list of (sorted) valid buffer states. Used for error output.
+func ValidStatesStr() string {
+	return strings.Join(validStates, ", ")
 }

--- a/actr/modules/modules.go
+++ b/actr/modules/modules.go
@@ -2,6 +2,8 @@
 package modules
 
 import (
+	"strings"
+
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -10,6 +12,11 @@ import (
 )
 
 const BuiltIn = "built-in"
+
+var validStates = []string{
+	"busy",
+	"error",
+}
 
 // Module is an ACT-R module
 type Module struct {
@@ -152,4 +159,14 @@ func FindModule(name string) ModuleInterface {
 	}
 
 	return nil
+}
+
+// IsValidState checks if 'state' is a valid module state.
+func IsValidState(state string) bool {
+	return slices.Contains(validStates, state)
+}
+
+// ValidStatesStr returns a list of valid module states. Used for error output.
+func ValidStatesStr() string {
+	return strings.Join(validStates, ", ")
 }

--- a/actr/production.go
+++ b/actr/production.go
@@ -58,8 +58,11 @@ func (c Constraint) String() string {
 }
 
 type Match struct {
-	Buffer  buffer.Interface
-	Pattern *Pattern
+	Buffer buffer.Interface
+
+	// matches either a pattern or a buffer status
+	Pattern      *Pattern
+	BufferStatus *string
 }
 
 type Statement struct {

--- a/amod/amod.go
+++ b/amod/amod.go
@@ -423,12 +423,24 @@ func addProductions(model *actr.Model, log *issueLog, productions *productionSec
 		}
 
 		for _, match := range production.Match.Items {
-			pattern, err := createChunkPattern(model, log, match.Pattern)
+			// check for buffer status match first
+			if match.BufferStatus != nil {
+				name := match.BufferStatus.Name
+				actrMatch := actr.Match{
+					Buffer:       model.LookupBuffer(name),
+					BufferStatus: &match.BufferStatus.Status,
+				}
+
+				prod.Matches = append(prod.Matches, &actrMatch)
+				continue
+			}
+
+			pattern, err := createChunkPattern(model, log, match.Chunk.Pattern)
 			if err != nil {
 				continue
 			}
 
-			name := match.Name
+			name := match.Chunk.Name
 			actrMatch := actr.Match{
 				Buffer:  model.LookupBuffer(name),
 				Pattern: pattern,
@@ -454,8 +466,8 @@ func addProductions(model *actr.Model, log *issueLog, productions *productionSec
 				}
 			}
 
-			if match.When != nil {
-				for _, expr := range *match.When.Expressions {
+			if match.Chunk.When != nil {
+				for _, expr := range *match.Chunk.When.Expressions {
 					comparison := actr.Equal
 
 					if expr.Comparison.NotEqual != nil {

--- a/amod/amod_productions_test.go
+++ b/amod/amod_productions_test.go
@@ -663,7 +663,7 @@ func Example_productionPrintStatement3() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: error] }
+		match { goal is empty }
 		do { print }
 	}`)
 
@@ -678,7 +678,7 @@ func Example_productionPrintStatementInvalidID() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: error] }
+		match { retrieval is empty }
 		do { print fooID }
 	}`)
 
@@ -694,7 +694,7 @@ func Example_productionPrintStatementInvalidNil() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: error] }
+		match { goal is empty }
 		do { print nil }
 	}`)
 
@@ -710,7 +710,7 @@ func Example_productionPrintStatementInvalidVar() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: error] }
+		match { retrieval is empty }
 		do { print ?fooVar }
 	}`)
 
@@ -726,7 +726,7 @@ func Example_productionPrintStatementWildcard() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: error] }
+		match { goal is empty }
 		do { print * }
 	}`)
 
@@ -734,7 +734,86 @@ func Example_productionPrintStatementWildcard() {
 	// ERROR: unexpected token "*" (expected "}") (line 9, col 13)
 }
 
-func Example_productionMatchInternal() {
+func Example_productionMatchBufferStatus() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { retrieval is empty }
+		do { print 42 }
+	}`)
+
+	// Output:
+}
+
+func Example_productionMatchBufferStatusInvalidBuffer() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { foo is empty }
+		do { print 42 }
+	}`)
+
+	// Output:
+	// ERROR: buffer 'foo' not found in production 'start' (line 8, col 10)
+}
+
+func Example_productionMatchBufferStatusInvalidStatus() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { retrieval is foo }
+		do { print 42 }
+	}`)
+
+	// Output:
+	// ERROR: invalid status 'foo' for buffer 'retrieval' in production 'start' (should be one of: empty, full) (line 8, col 10)
+}
+
+func Example_productionMatchBufferStatusInvalidString() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal is 'empty' }
+		do { print 42 }
+	}`)
+
+	// Output:
+	// ERROR: unexpected token "empty" (expected <ident>) (line 8, col 18)
+}
+
+func Example_productionMatchBufferStatusInvalidNumber() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal is 42 }
+		do { print 42 }
+	}`)
+
+	// Output:
+	// ERROR: unexpected token "42" (expected <ident>) (line 8, col 18)
+}
+
+func Example_productionMatchModuleStatus() {
 	generateToStdout(`
 	~~ model ~~
 	name: Test
@@ -749,7 +828,7 @@ func Example_productionMatchInternal() {
 	// Output:
 }
 
-func Example_productionMatchInternalSlots() {
+func Example_productionMatchModuleStatusInvalidStatus1() {
 	generateToStdout(`
 	~~ model ~~
 	name: Test
@@ -757,15 +836,15 @@ func Example_productionMatchInternalSlots() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { retrieval [_status: busy error] }
+		match { retrieval [_status: 'foo'] }
 		do { print 42 }
 	}`)
 
 	// Output:
-	// ERROR: invalid chunk - '_status' expects 1 slot (line 8, col 20)
+	// ERROR: invalid _status for 'retrieval' in production 'start' (should be one of: busy, error) (line 8, col 30)
 }
 
-func Example_productionMatchInternalInvalidStatus1() {
+func Example_productionMatchModuleStatusInvalidStatus2() {
 	generateToStdout(`
 	~~ model ~~
 	name: Test
@@ -773,58 +852,10 @@ func Example_productionMatchInternalInvalidStatus1() {
 	~~ init ~~
 	~~ productions ~~
 	start {
-		match { goal [_status: something] }
+		match { retrieval [ _status: bar ] }
 		do { print 42 }
 	}`)
 
 	// Output:
-	// ERROR: invalid _status 'something' for 'goal' in production 'start' (should be 'busy', 'empty', 'error', 'full') (line 8, col 25)
-}
-
-func Example_productionMatchInternalInvalidStatus2() {
-	generateToStdout(`
-	~~ model ~~
-	name: Test
-	~~ config ~~
-	~~ init ~~
-	~~ productions ~~
-	start {
-		match { retrieval [_status: something] }
-		do { print 42 }
-	}`)
-
-	// Output:
-	// ERROR: invalid _status 'something' for 'retrieval' in production 'start' (should be 'busy', 'empty', 'error', 'full') (line 8, col 30)
-}
-
-func Example_productionMatchInternalInvalidStatusString() {
-	generateToStdout(`
-	~~ model ~~
-	name: Test
-	~~ config ~~
-	~~ init ~~
-	~~ productions ~~
-	start {
-		match { goal [_status: 'something'] }
-		do { print 42 }
-	}`)
-
-	// Output:
-	// ERROR: invalid _status for 'goal' in production 'start' (should be 'busy', 'empty', 'error', 'full') (line 8, col 25)
-}
-
-func Example_productionMatchInternalInvalidStatusNumber() {
-	generateToStdout(`
-	~~ model ~~
-	name: Test
-	~~ config ~~
-	~~ init ~~
-	~~ productions ~~
-	start {
-		match { goal [_status: 42] }
-		do { print 42 }
-	}`)
-
-	// Output:
-	// ERROR: invalid _status for 'goal' in production 'start' (should be 'busy', 'empty', 'error', 'full') (line 8, col 25)
+	// ERROR: invalid _status 'bar' for 'retrieval' in production 'start' (should be one of: busy, error) (line 8, col 31)
 }

--- a/amod/lex.go
+++ b/amod/lex.go
@@ -131,6 +131,7 @@ var keywords []string = []string{
 	"do",
 	"examples",
 	"gactar",
+	"is",
 	"match",
 	"modules",
 	"name",

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -221,10 +221,24 @@ type whenClause struct {
 	Tokens []lexer.Token
 }
 
-type matchItem struct {
+type matchChunkItem struct {
 	Name    string      `parser:"@Ident"`
 	Pattern *pattern    `parser:"@@"`
 	When    *whenClause `parser:"@@?"`
+
+	Tokens []lexer.Token
+}
+
+type matchBufferStatusItem struct {
+	Name   string `parser:"@Ident"`
+	Status string `parser:"'is' @Ident"`
+
+	Tokens []lexer.Token
+}
+
+type matchItem struct {
+	Chunk        *matchChunkItem        `parser:"( @@"`
+	BufferStatus *matchBufferStatusItem `parser:"| @@)"`
 
 	Tokens []lexer.Token
 }

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -471,22 +471,15 @@ func (c CCMPyACTR) outputPattern(pattern *actr.Pattern) {
 }
 
 func (c CCMPyACTR) outputMatch(match *actr.Match) {
-	var name string
-	if match.Buffer != nil {
-		name = match.Buffer.BufferName()
-	}
+	bufferName := match.Buffer.BufferName()
 
-	chunkTypeName := match.Pattern.Chunk.TypeName
-	if actr.IsInternalChunkType(chunkTypeName) {
-		if chunkTypeName == "_status" {
-			status := match.Pattern.Slots[0]
-			if name == "retrieval" {
-				name = "memory"
-			}
-			c.Write("%s='%s:True'", name, status)
+	if match.BufferStatus != nil {
+		if bufferName == "retrieval" {
+			bufferName = "memory"
 		}
+		c.Write("%s='%s:True'", bufferName, *match.BufferStatus)
 	} else {
-		c.Write("%s=", name)
+		c.Write("%s=", bufferName)
 		c.outputPattern(match.Pattern)
 	}
 }

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -476,23 +476,23 @@ func (p PyACTR) outputPattern(pattern *actr.Pattern, tabs int) {
 
 func (p PyACTR) outputMatch(match *actr.Match) {
 	bufferName := match.Buffer.BufferName()
-	chunkName := match.Pattern.Chunk.TypeName
 
-	if actr.IsInternalChunkType(chunkName) {
-		if chunkName == "_status" {
-			status := match.Pattern.Slots[0]
-			p.Writeln("     ?%s>", bufferName)
+	if match.BufferStatus != nil {
+		p.Writeln("     ?%s>", bufferName)
+		p.Writeln("          buffer %s", *match.BufferStatus)
+	} else {
+		chunkName := match.Pattern.Chunk.TypeName
 
-			// Table 2.1 page 24 of pyactr book
-			if status.String() == "full" || status.String() == "empty" {
-				p.Writeln("          buffer %s", status)
-			} else {
+		if actr.IsInternalChunkType(chunkName) {
+			if chunkName == "_status" {
+				status := match.Pattern.Slots[0]
+				p.Writeln("     ?%s>", bufferName)
 				p.Writeln("          state %s", status)
 			}
+		} else {
+			p.Writeln("     =%s>", bufferName)
+			p.outputPattern(match.Pattern, 2)
 		}
-	} else {
-		p.Writeln("     =%s>", bufferName)
-		p.outputPattern(match.Pattern, 2)
 	}
 }
 

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -474,22 +474,22 @@ func (v VanillaACTR) outputPattern(pattern *actr.Pattern, tabs int) {
 
 func (v VanillaACTR) outputMatch(match *actr.Match) {
 	bufferName := match.Buffer.BufferName()
-	chunkTypeName := match.Pattern.Chunk.TypeName
+	if match.BufferStatus != nil {
+		v.Writeln("\t?%s>", bufferName)
+		v.Writeln("\t\tbuffer %s", *match.BufferStatus)
+	} else {
+		chunkTypeName := match.Pattern.Chunk.TypeName
 
-	if actr.IsInternalChunkType(chunkTypeName) {
-		if chunkTypeName == "_status" {
-			status := match.Pattern.Slots[0]
-			v.Writeln("\t?%s>", bufferName)
-
-			if status.String() == "full" || status.String() == "empty" {
-				v.Writeln("\t\tbuffer %s", status)
-			} else {
+		if actr.IsInternalChunkType(chunkTypeName) {
+			if chunkTypeName == "_status" {
+				status := match.Pattern.Slots[0]
+				v.Writeln("\t?%s>", bufferName)
 				v.Writeln("\t\tstate %s", status)
 			}
+		} else {
+			v.Writeln("\t=%s>", bufferName)
+			v.outputPattern(match.Pattern, 2)
 		}
-	} else {
-		v.Writeln("\t=%s>", bufferName)
-		v.outputPattern(match.Pattern, 2)
 	}
 }
 


### PR DESCRIPTION
Instead of:

	match { retrieval [_status: empty] }

buffer checks are now done like this:

	match { retrieval is empty }

Module state checks are still done using `_status` chunks and will be changed in a future PR.

Part of #222