### PR TITLE
{ccm} Fix goal's spreading activation so if it isn't set explicitly it defaults to 0.0

### DIFF
--- a/actr/modules/goal.go
+++ b/actr/modules/goal.go
@@ -10,8 +10,8 @@ type Goal struct {
 	Module
 
 	// "spreading_activation": see "Spreading Activation" in "ACT-R 7.26 Reference Manual" pg. 290
-	// 	ccm (DMSpreading.weight): 1.0
-	// 	pyactr (buffer_spreading_activation): no default
+	// 	ccm (DMSpreading.weight): 0.0
+	// 	pyactr (buffer_spreading_activation): 0.0
 	// 	vanilla (:ga): 0.0
 	SpreadingActivation *float64
 }

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -220,7 +220,11 @@ func (c *CCMPyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code 
 		c.Writeln("    spread.strength = %s", numbers.Float64Str(*memory.MaxSpreadStrength))
 
 		goalActivation := c.model.Goal.SpreadingActivation
-		if goalActivation != nil {
+		if goalActivation == nil {
+			// if it isn't set, then it should default to 0.0
+			// ACR-T Manual pg. 275
+			c.Writeln("    spread.weight[%s] = 0.0", "goal")
+		} else {
 			c.Writeln("    spread.weight[%s] = %s", "goal", numbers.Float64Str(*goalActivation))
 		}
 


### PR DESCRIPTION
This is the default according to the ACR-T manual (pg. 275).

Related to #325