### PR TITLE
{web} Add logging options to UI

### DIFF
--- a/modes/web/gactar-web/src/api.ts
+++ b/modes/web/gactar-web/src/api.ts
@@ -54,9 +54,19 @@ async function getFrameworks(): Promise<FrameworkInfoList> {
 }
 
 // run
+export const logLevels: string[] = ['min', 'info', 'detail']
+
 export interface RunOptions {
+  // List of frameworks to run
+  frameworks: string[]
+
+  // Log level - one of 'min', 'info', or 'detail'
   logLevel: string
+
+  // Output detailed info about activations
   traceActivations: boolean
+
+  // Seed to use for generating pseudo-random numbers
   randomSeed?: number
 }
 
@@ -67,11 +77,8 @@ export interface RunParams {
   // The starting goal.
   goal: string
 
-  // An optional list of frameworks ("all" if not set).
-  frameworks?: string[]
-
-  // optional options!
-  options?: RunOptions
+  // options!
+  options: RunOptions
 }
 
 // Location of an issue in the source code.
@@ -158,11 +165,11 @@ export interface SessionRunParams {
   // The initial contents of the buffers.
   buffers: string
 
-  // An optional list of frameworks ("all" if not set).
-  frameworks?: string[]
-
   // Whether to include the generated code as part of the response.
   includeCode: boolean
+
+  // options!
+  options: RunOptions
 }
 
 export interface SessionRunResult extends FrameworkResult {

--- a/modes/web/gactar-web/src/app.scss
+++ b/modes/web/gactar-web/src/app.scss
@@ -63,6 +63,11 @@ textarea {
   font-size: 14px;
 }
 
+.icon.is-tiny {
+  height: 0.75rem;
+  width: 0.75rem;
+}
+
 .icon-space {
   margin-right: 0.5em;
 }
@@ -108,5 +113,15 @@ textarea {
     border: 1px solid $tab-border-color;
     border-top-color: transparent !important;
     padding: 0.5rem 0 0 0;
+  }
+}
+
+.tile.is-small-gap {
+  .tile.is-parent {
+    padding: 0.66rem;
+  }
+
+  .tile.is-vertical > .tile.is-child:not(:last-child) {
+    margin-bottom: 0.66rem !important;
   }
 }

--- a/modes/web/gactar-web/src/components/AmodCodeTab.vue
+++ b/modes/web/gactar-web/src/components/AmodCodeTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-tab-item label="amod">
+  <b-tab-item label="amod" value="amod-code">
     <div class="columns buttons">
       <div class="column">
         <b-field class="is-pulled-right" grouped>

--- a/modes/web/gactar-web/src/components/FrameworkCodeTab.vue
+++ b/modes/web/gactar-web/src/components/FrameworkCodeTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-tab-item class="code-tab" :label="framework.name">
+  <b-tab-item class="code-tab" :label="framework.name" :value="framework.name">
     <div class="columns buttons">
       <div class="column">
         <strong>{{ defaultFileName }}.{{ framework.fileExtension }}</strong>

--- a/modes/web/gactar-web/src/components/RunOptionsPanel.vue
+++ b/modes/web/gactar-web/src/components/RunOptionsPanel.vue
@@ -1,0 +1,139 @@
+<template>
+  <b-collapse
+    :open.sync="open"
+    class="card"
+    animation="slide"
+    aria-id="runOptionPanel"
+  >
+    <template #trigger="props">
+      <div
+        class="card-header"
+        role="button"
+        aria-controls="runOptionPanel"
+        :aria-expanded="props.open"
+      >
+        <p class="card-header-title is-size-7">Run Options</p>
+        <a class="card-header-icon">
+          <b-icon
+            pack="fas"
+            size="is-tiny"
+            type="is-info"
+            v-show="!props.open"
+            icon="caret-down"
+          />
+          <b-icon
+            pack="fas"
+            size="is-tiny"
+            type="is-info"
+            v-show="props.open"
+            icon="caret-up"
+          />
+        </a>
+      </div>
+    </template>
+
+    <div class="card-content p-0">
+      <div class="tile is-small-gap is-child">
+        <div class="tile is-vertical is-parent">
+          <div class="tile is-child">
+            <div v-if="availableFrameworks.length > 0">
+              <b-field label="Select Frameworks" custom-class="is-small">
+                <b-checkbox-button
+                  v-for="name in availableFrameworks"
+                  v-model="runOptions.frameworks"
+                  type="is-info"
+                  size="is-small"
+                  :native-value="name"
+                  :key="name"
+                  expanded
+                  class="ml-1 mr-1"
+                  @input="runOptionsChanged"
+                >
+                  <span>{{ name }}</span>
+                </b-checkbox-button>
+              </b-field>
+            </div>
+          </div>
+
+          <div class="tile is-child">
+            <b-field label="Logging Level" custom-class="is-small">
+              <b-radio-button
+                v-for="name in logLevels"
+                v-model="runOptions.logLevel"
+                type="is-info"
+                size="is-small"
+                :native-value="name"
+                :key="name"
+                expanded
+                class="ml-1 mr-1"
+                @input="runOptionsChanged"
+              >
+                <span>{{ name }}</span>
+              </b-radio-button>
+
+              <b-checkbox
+                v-model="runOptions.traceActivations"
+                type="is-info"
+                expanded
+                class="is-small pl-3"
+                @input="runOptionsChanged"
+              >
+                Trace activations
+              </b-checkbox>
+            </b-field>
+          </div>
+        </div>
+      </div>
+    </div>
+  </b-collapse>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue'
+
+import { logLevels, RunOptions } from '../api'
+
+interface Data {
+  open: boolean
+  runOptions: RunOptions
+}
+
+export default defineComponent({
+  props: {
+    availableFrameworks: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+    options: {
+      type: Object as PropType<RunOptions>,
+      required: true,
+    },
+  },
+
+  data(): Data {
+    return { open: true, runOptions: this.options }
+  },
+
+  computed: {
+    isOpen(): boolean {
+      return this.open
+    },
+
+    logLevels(): string[] {
+      return logLevels
+    },
+  },
+
+  watch: {
+    options: function (newOptions, _) {
+      this.runOptions = newOptions
+    },
+  },
+
+  methods: {
+    runOptionsChanged() {
+      this.$emit('options-change', this.runOptions)
+    },
+  },
+})
+</script>

--- a/modes/web/gactar-web/src/main.ts
+++ b/modes/web/gactar-web/src/main.ts
@@ -41,13 +41,22 @@ Vue.use(Buefy, {
 import { dom, library } from '@fortawesome/fontawesome-svg-core'
 import { faCaretSquareDown } from '@fortawesome/free-regular-svg-icons'
 import {
+  faCaretDown,
+  faCaretUp,
   faFileDownload,
   faFileUpload,
   faRunning,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
-library.add(faCaretSquareDown, faFileDownload, faFileUpload, faRunning)
+library.add(
+  faCaretDown,
+  faCaretUp,
+  faCaretSquareDown,
+  faFileDownload,
+  faFileUpload,
+  faRunning
+)
 dom.watch()
 
 Vue.component('FontAwesomeIcon', FontAwesomeIcon)


### PR DESCRIPTION
Also fixes two issues:

- The UI wasn't properly saving/restoring the list of selected frameworks.

- If the user ran with a framework selected and selected the code or result tab for it, then turned off that framework and ran again, the tabs would be in a strange state. Instead, select the main tab if the tab no longer exists.

Fixes #253