### PR TITLE
Handle the "recently_retrieved" request parameter on the retrieval buffer

### DIFF
--- a/actr/modules/goal.go
+++ b/actr/modules/goal.go
@@ -16,6 +16,10 @@ type Goal struct {
 	SpreadingActivation *float64
 }
 
+type goalBuffer struct {
+	buffer.Buffer
+}
+
 // NewGoal creates and returns a new Goal module
 func NewGoal() *Goal {
 	spreadingActivation := NewParamFloat(
@@ -24,14 +28,18 @@ func NewGoal() *Goal {
 		Ptr(0.0), nil,
 	)
 
+	goalBuff := goalBuffer{
+		buffer.Buffer{
+			Name: "goal", MultipleInit: false,
+		},
+	}
+
 	return &Goal{
 		Module: Module{
 			Name:        "goal",
 			Version:     BuiltIn,
 			Description: "provides a goal buffer for the model",
-			BufferList: buffer.List{
-				{Name: "goal", MultipleInit: false},
-			},
+			BufferList:  buffer.List{goalBuff},
 			Params: ParamInfoMap{
 				"spreading_activation": spreadingActivation,
 			},

--- a/actr/modules/imaginal.go
+++ b/actr/modules/imaginal.go
@@ -24,14 +24,17 @@ func NewImaginal() *Imaginal {
 		Ptr(0.0), nil,
 	)
 
+	imaginalBuffer := goalBuffer{
+		buffer.Buffer{
+			Name: "imaginal", MultipleInit: false,
+		},
+	}
 	return &Imaginal{
 		Module: Module{
 			Name:        "imaginal",
 			Version:     BuiltIn,
 			Description: "provides a goal style buffer with a delay and an action buffer for manipulating the imaginal chunk",
-			BufferList: buffer.List{
-				{Name: "imaginal", MultipleInit: false},
-			},
+			BufferList:  buffer.List{imaginalBuffer},
 			Params: ParamInfoMap{
 				"delay": delay,
 			},

--- a/actr/production.go
+++ b/actr/production.go
@@ -127,8 +127,9 @@ type PrintStatement struct {
 
 // RecallStatement is used to pull information from memory.
 type RecallStatement struct {
-	Pattern    *Pattern
-	MemoryName string
+	Pattern           *Pattern
+	MemoryModuleName  string
+	RequestParameters map[string]string
 }
 
 type SetSlot struct {

--- a/amod/amod.go
+++ b/amod/amod.go
@@ -707,10 +707,20 @@ func createRecallStatement(model *actr.Model, log *issueLog, recall *recallState
 		return nil, err
 	}
 
+	requestParameters := make(map[string]string)
+
+	if recall.With != nil {
+		for _, param := range *recall.With.Expressions {
+			value := convertArg(param.Value)
+			requestParameters[param.Param] = value.String()
+		}
+	}
+
 	s := actr.Statement{
 		Recall: &actr.RecallStatement{
-			Pattern:    pattern,
-			MemoryName: model.Memory.ModuleName(),
+			Pattern:           pattern,
+			MemoryModuleName:  model.Memory.ModuleName(),
+			RequestParameters: requestParameters,
 		},
 	}
 

--- a/amod/amod_productions_test.go
+++ b/amod/amod_productions_test.go
@@ -582,6 +582,137 @@ func Example_productionRecallStatementVarNotFound() {
 	// ERROR: recall statement variable '?next' not found in matches for production 'start' (line 10, col 20)
 }
 
+func Example_productionRecallStatementWithWith() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved reset ) }
+	}`)
+
+	// Output:
+}
+
+func Example_productionRecallStatementWithMultipleWith() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved reset ) and ( recently_retrieved t ) }
+	}`)
+
+	// Output:
+}
+
+func Example_productionRecallStatementWithInvalidParam() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( foo_param 42 ) }
+	}`)
+
+	// Output:
+	// ERROR: recall 'with': invalid parameter 'foo_param'. Expected one of: recently_retrieved (line 10, col 34)
+}
+
+func Example_productionRecallStatementWithNIL() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved nil ) }
+	}`)
+
+	// Output:
+}
+
+func Example_productionRecallStatementWithID() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved t ) }
+	}`)
+
+	// Output:
+}
+
+func Example_productionRecallStatementWithString() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved "bar" ) }
+	}`)
+
+	// Output:
+	// ERROR: recall 'with': invalid value "bar" for parameter "recently_retrieved" (expected one of: t, nil, reset). (line 10, col 34)
+}
+
+func Example_productionRecallStatementWithVar() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved ?bar ) }
+	}`)
+
+	// Output:
+	// ERROR: recall 'with': parameter 'recently_retrieved'. Unexpected variable (line 10, col 34)
+}
+
+func Example_productionRecallStatementWithIncorrectNumArgs() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	chunks { [foo: thing1 thing2] }
+	~~ init ~~
+	~~ productions ~~
+	start {
+		match { goal [foo: ?next *] }
+		do { recall [foo: ?next *] with ( recently_retrieved nil nil ) }
+	}`)
+
+	// Output:
+	// ERROR: unexpected token "nil" (expected ")") (line 10, col 59)
+}
 func Example_productionMultipleStatement() {
 	generateToStdout(`
 	~~ model ~~

--- a/amod/lex.go
+++ b/amod/lex.go
@@ -144,6 +144,7 @@ var keywords []string = []string{
 	"stop",
 	"to",
 	"when",
+	"with",
 }
 
 // Symbols provides a mapping from participle strings to our lexemes

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -59,6 +59,27 @@ type arg struct {
 	Tokens []lexer.Token
 }
 
+func (f arg) String() string {
+	switch {
+	case f.Nil != nil:
+		return "nil"
+
+	case f.Var != nil:
+		return *f.Var
+
+	case f.ID != nil:
+		return *f.ID
+
+	case f.Str != nil:
+		return *f.Str
+
+	case f.Number != nil:
+		return *f.Number
+	}
+
+	return "<error>"
+}
+
 type fieldValue struct {
 	Colon  string   `parser:"(':'"`
 	ID     *string  `parser:"(  @Ident"`
@@ -231,14 +252,14 @@ type matchBufferPatternItem struct {
 
 type matchBufferStateItem struct {
 	Name  string `parser:"@Ident"`
-	State string `parser:"'state' @Ident"`
+	State string `parser:"'state':Keyword @Ident"`
 
 	Tokens []lexer.Token
 }
 
 type matchModuleStateItem struct {
 	Name  string `parser:"@Ident"`
-	State string `parser:"'module' @Ident"`
+	State string `parser:"'module':Keyword @Ident"`
 
 	Tokens []lexer.Token
 }
@@ -269,8 +290,25 @@ type printStatement struct {
 	Tokens []lexer.Token
 }
 
+type withExpression struct {
+	OpenParen  string `parser:"'('"` // not used - must be set for parse
+	Param      string `parser:"@Ident"`
+	Value      *arg   `parser:"@@"`
+	CloseParen string `parser:"')'"` // not used - must be set for parse
+
+	Tokens []lexer.Token
+}
+
+type withClause struct {
+	With        string             `parser:"'with':Keyword"`
+	Expressions *[]*withExpression `parser:"@@ ('and':Keyword @@)*"`
+
+	Tokens []lexer.Token
+}
+
 type recallStatement struct {
-	Pattern *pattern `parser:"'recall' @@"`
+	Pattern *pattern    `parser:"'recall' @@"`
+	With    *withClause `parser:"@@?"`
 
 	Tokens []lexer.Token
 }

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/asmaloney/gactar/actr/modules"
@@ -75,7 +76,14 @@ func info(args []string) {
 
 			writer := tabwriter.NewWriter(os.Stdout, 1, 1, 3, ' ', 0)
 			for _, buffer := range mod.Buffers() {
-				fmt.Fprintf(writer, "\t%s", chalk.Italic(buffer.Name))
+				fmt.Fprintf(writer, "\t%s", chalk.Italic(buffer.BufferName()))
+
+				if buffer.HasRequestParameters() {
+					fmt.Fprintf(writer, "\t%s %s",
+						chalk.Header("Request Parameters:"),
+						chalk.Italic(strings.Join(buffer.RequestParameterNames(), ", ")),
+					)
+				}
 			}
 			writer.Flush()
 
@@ -83,7 +91,7 @@ func info(args []string) {
 		}
 
 		if mod.HasParameters() {
-			fmt.Println(chalk.Header(" Parameters"))
+			fmt.Println(chalk.Header(" Module Parameters"))
 			params := mod.Parameters()
 
 			writer := tabwriter.NewWriter(os.Stdout, 1, 1, 3, ' ', 0)

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/asmaloney/gactar/actr"
 	"github.com/asmaloney/gactar/framework"
 
@@ -553,6 +555,26 @@ func addPatternSlot(tabbedItems *framework.KeyValueList, slotName string, slot *
 	}
 }
 
+func (p VanillaACTR) outputRequestParameters(params map[string]string, tabs int) {
+	tabbedItems := framework.KeyValueList{}
+
+	for _, param := range maps.Keys(params) {
+		if param != "recently_retrieved" {
+			continue
+		}
+
+		name := param
+
+		if param == "recently_retrieved" {
+			name = ":recently-retrieved"
+		}
+
+		tabbedItems.Add(name, params[param])
+	}
+
+	p.TabWrite(tabs, tabbedItems)
+}
+
 func (v VanillaACTR) outputStatement(s *actr.Statement) {
 	switch {
 	case s.Set != nil:
@@ -592,6 +614,7 @@ func (v VanillaACTR) outputStatement(s *actr.Statement) {
 	case s.Recall != nil:
 		v.Writeln("\t+retrieval>")
 		v.outputPattern(s.Recall.Pattern, 2)
+		v.outputRequestParameters(s.Recall.RequestParameters, 2)
 
 	case s.Print != nil:
 		outputArgs := createOutputArgs(s.Print.Values)


### PR DESCRIPTION
Specified like this in a production:

        recall [item: * ?group] with (recently_retrieved nil)

Valid values are `t`, `nil`, and `reset`.

Only _vanilla_ works with all values. _pyactr_ only supports `nil`, while _python_actr_ doesn't support request parameters at all.

Fixes #233