### PR TITLE
Allow buffer options in module config

### DIFF
--- a/actr/buffer/buffer.go
+++ b/actr/buffer/buffer.go
@@ -105,7 +105,7 @@ func (b buffer) Parameters() param.ParametersInterface {
 	return b.parameters
 }
 
-func (b buffer) SetParam(param *keyvalue.KeyValue) (err error) {
+func (b *buffer) SetParam(param *keyvalue.KeyValue) (err error) {
 	err = b.Parameters().ValidateParam(param)
 	if err != nil {
 		return

--- a/actr/modules/goal.go
+++ b/actr/modules/goal.go
@@ -2,60 +2,28 @@ package modules
 
 import (
 	"github.com/asmaloney/gactar/actr/buffer"
-	"github.com/asmaloney/gactar/actr/param"
-
-	"github.com/asmaloney/gactar/util/keyvalue"
 )
 
 // Goal is a module which provides the ACT-R "goal" buffer.
 type Goal struct {
 	Module
+}
 
-	// "spreading_activation": see "Spreading Activation" in "ACT-R 7.26 Reference Manual" pg. 290
-	// 	ccm (DMSpreading.weight): 0.0
-	// 	pyactr (buffer_spreading_activation): 0.0
-	// 	vanilla (:ga): 0.0
-	SpreadingActivation *float64
+func (g Goal) Buffer() buffer.Interface {
+	return g.BufferList.At(0)
 }
 
 // NewGoal creates and returns a new Goal module
 func NewGoal() *Goal {
-	spreadingActivation := param.NewFloat(
-		"spreading_activation",
-		"spreading activation weight",
-		param.Ptr(0.0), nil,
-	)
-
-	parameters := param.NewParameters(param.List{
-		spreadingActivation,
-	})
-
 	goalBuff := buffer.NewBuffer("goal", 0.0, nil)
 
 	return &Goal{
 		Module: Module{
-			Name:                "goal",
-			Version:             BuiltIn,
-			Description:         "provides a goal buffer for the model",
-			BufferList:          buffer.List{goalBuff},
-			ParametersInterface: parameters,
-			MultipleInit:        false,
+			Name:         "goal",
+			Version:      BuiltIn,
+			Description:  "provides a goal buffer for the model",
+			BufferList:   buffer.List{goalBuff},
+			MultipleInit: false,
 		},
 	}
-}
-
-// SetParam is called to set our module's parameter from the parameter in the code ("param")
-func (g *Goal) SetParam(param *keyvalue.KeyValue) (err error) {
-	err = g.ValidateParam(param)
-	if err != nil {
-		return
-	}
-
-	value := param.Value
-
-	if param.Key == "spreading_activation" {
-		g.SpreadingActivation = value.Number
-	}
-
-	return
 }

--- a/amod/amod_config_test.go
+++ b/amod/amod_config_test.go
@@ -64,7 +64,7 @@ func Example_gactarFieldNotANestedValue() {
 	~~ productions ~~`)
 
 	// Output:
-	// ERROR: 'log_level' invalid type (found <none>; expected string) (line 5, col 21)
+	// ERROR: 'log_level' invalid type (found field; expected string) (line 5, col 21)
 }
 
 func Example_gactarSpaceSeparator() {
@@ -170,6 +170,22 @@ func Example_modulesMultipleBuffers() {
 			buffer1 {}
 			buffer2 {}
 		} 
+	}
+	~~ init ~~
+	~~ productions ~~`)
+
+	// Output:
+}
+
+func Example_modulesInitBuffer() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	modules {
+		memory {
+			retrieval { spreading_activation: 0.5 }
+		}
 	}
 	~~ init ~~
 	~~ productions ~~`)

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -87,8 +87,9 @@ type fieldValue struct {
 	Number *float64 `parser:"| @Number )"`
 
 	// We can't capture an empty field "{}", so capture the open brace to tell us it's a nested field
-	OpenBrace *string `parser:"| @('{')"`
-	Field     *field  `parser:"@@? '}' )"`
+	OpenBrace  *string  `parser:"| @('{')"`
+	Fields     []*field `parser:"@@*"`
+	CloseBrace *string  `parser:"'}')"`
 
 	Tokens []lexer.Token
 }

--- a/doc/amod Config.md
+++ b/doc/amod Config.md
@@ -23,6 +23,16 @@ gactar {
 
 gactar supports a handful of modules and configuration options which are set in the `modules` section.
 
+A module's buffer is configured using its name like this:
+
+```
+modules {
+    memory {
+        retrieval { spreading_activation: 0.5 }
+    }
+}
+```
+
 For a list of a specific module's configuration options, run `gactar module info [module name]`.
 
 For a list of _all_ modules and their configuration options, run `gactar module info all`.
@@ -37,7 +47,7 @@ modules {
     }
 
     goal {
-        spreading_activation: 1.0
+        goal{ spreading_activation: 1.0 }
     }
 
     extra_buffers {
@@ -46,6 +56,39 @@ modules {
     }
 }
 ```
+
+### Buffers
+
+All buffers have one configuration option.
+
+| Config               | Type    | Description                                                         |
+| -------------------- | ------- | ------------------------------------------------------------------- |
+| spreading_activation | decimal | see "Spreading Activation" in "ACT-R 7.26 Reference Manual" pg. 290 |
+
+Mapping defaults is a little messy since they are handled differently in each of the frameworks.
+
+- **ccm** (DMSpreading.weight): defaults to 1.0, however this is incorrect, so we explicitly set it to 0.0
+- **pyactr**: if not set explicitly, defaults to 0.0
+- **vanilla**: (_see below_)
+
+Here are vanilla's parameters and defaults:
+
+| buffer                 | ACT-R param                 | default |
+| ---------------------- | --------------------------- | ------- |
+| Aural buffer           | :aural-activation           | 0.0     |
+| Aural-location buffer  | :aural-location-activation  | 0.0     |
+| Goal buffer            | :ga                         | 0.0     |
+| Imaginal buffer        | :imaginal-activation        | 1.0     |
+| Imaginal-action buffer | :imaginal-action-activation | 0.0     |
+| Manual buffer          | :manual-activation          | 0.0     |
+| Production buffer      | :production-activation      | 0.0     |
+| Retrieval buffer       | :retrieval-activation       | 0.0     |
+| Temporal buffer        | :temporal-activation        | 0.0     |
+| Visual buffer          | :visual-activation          | 0.0     |
+| Visual-location buffer | :visual-location-activation | 0.0     |
+| Vocal buffer           | :vocal-activation           | 0.0     |
+
+Right now, we allow setting the spreading activation on any buffer, however we only generate code for the `goal` buffer.
 
 ### Declarative Memory
 
@@ -75,9 +118,7 @@ Module Name: **goal**
 
 Buffer Name: **goal**
 
-| Config               | Type    | Description                                                         | Mapping                                                                                          |
-| -------------------- | ------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| spreading_activation | decimal | see "Spreading Activation" in "ACT-R 7.26 Reference Manual" pg. 290 | ccm (DMSpreading.weight): 1.0<br>pyactr (buffer_spreading_activation): _no default_<br>vanilla (:ga): 0.0 |
+It does not have any additional configuration options.
 
 ### Imaginal
 
@@ -111,6 +152,6 @@ Module Name: **extra_buffers**
 
 Buffer Names: _specified in configuration_
 
-| Config           | Description                                                                                            |
-| ---------------- | ------------------------------------------------------------------------------------------------------ |
-| _buffer name_ {} | the name of the new buffer (with "{}" to allow the possibility of buffer config options in the future) |
+| Config           | Description                                                               |
+| ---------------- | ------------------------------------------------------------------------- |
+| _buffer name_ {} | the name of the new buffer (with "{}" to allow any buffer config options) |

--- a/doc/amod EBNF.txt
+++ b/doc/amod EBNF.txt
@@ -21,7 +21,7 @@ Field    ::= ident FieldValue
 
 FieldValue
          ::= ':' ( ident | string | number )
-           | '{' Field? '}'
+           | '{' Field* '}'
 
 Module   ::= ident '{' Field* '}'
 

--- a/framework/ccm_pyactr/ccm_pyactr.go
+++ b/framework/ccm_pyactr/ccm_pyactr.go
@@ -240,14 +240,9 @@ func (c *CCMPyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code 
 		c.Writeln("    spread = DMSpreading(%s, goal)", memory.ModuleName())
 		c.Writeln("    spread.strength = %s", numbers.Float64Str(*memory.MaxSpreadStrength))
 
-		goalActivation := c.model.Goal.SpreadingActivation
-		if goalActivation == nil {
-			// if it isn't set, then it should default to 0.0
-			// ACR-T Manual pg. 275
-			c.Writeln("    spread.weight[%s] = 0.0", "goal")
-		} else {
-			c.Writeln("    spread.weight[%s] = %s", "goal", numbers.Float64Str(*goalActivation))
-		}
+		goalActivation := c.model.Goal.Buffer().SpreadingActivation()
+
+		c.Writeln("    spread.weight[%s] = %s", "goal", numbers.Float64Str(goalActivation))
 
 		c.Writeln("")
 	}

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -233,9 +233,9 @@ func (p *PyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code []b
 	if memory.MaxSpreadStrength != nil {
 		p.Writeln("    strength_of_association=%s,", numbers.Float64Str(*memory.MaxSpreadStrength))
 
-		goalActivation := p.model.Goal.SpreadingActivation
-		if goalActivation != nil {
-			p.Writeln("    buffer_spreading_activation={'g': %s},", numbers.Float64Str(*goalActivation))
+		goalActivation := p.model.Goal.Buffer().SpreadingActivation()
+		if goalActivation != 0.0 {
+			p.Writeln("    buffer_spreading_activation={'g': %s},", numbers.Float64Str(goalActivation))
 		}
 	}
 

--- a/framework/vanilla_actr/vanilla_actr.go
+++ b/framework/vanilla_actr/vanilla_actr.go
@@ -230,9 +230,9 @@ func (v *VanillaACTR) GenerateCode(initialBuffers framework.InitialBuffers) (cod
 	if memory.MaxSpreadStrength != nil {
 		v.Writeln("\t:mas %s", numbers.Float64Str(*memory.MaxSpreadStrength))
 
-		goalActivation := v.model.Goal.SpreadingActivation
-		if goalActivation != nil {
-			v.Writeln("\t:ga %s", numbers.Float64Str(*goalActivation))
+		goalActivation := v.model.Goal.Buffer().SpreadingActivation()
+		if goalActivation != 0.0 {
+			v.Writeln("\t:ga %s", numbers.Float64Str(goalActivation))
 		}
 	}
 

--- a/util/keyvalue/keyvalue.go
+++ b/util/keyvalue/keyvalue.go
@@ -3,6 +3,7 @@ package keyvalue
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/exp/slices"
 )
@@ -17,7 +18,7 @@ type Value struct {
 	ID     *string
 	Str    *string
 	Number *float64
-	Field  *KeyValue
+	Fields *[]KeyValue
 }
 
 // KeyValue is the key/value of a parameter from the parsed amod code.
@@ -27,7 +28,7 @@ type KeyValue struct {
 }
 
 func (v Value) IsSet() bool {
-	return v.ID != nil || v.Str != nil || v.Number != nil || v.Field != nil
+	return v.ID != nil || v.Str != nil || v.Number != nil || v.Fields != nil
 }
 
 func (v Value) String() string {
@@ -41,8 +42,13 @@ func (v Value) String() string {
 	case v.Number != nil:
 		return fmt.Sprintf("%f", *v.Number)
 
-	case v.Field != nil:
-		return fmt.Sprintf("{ %s }", *v.Field)
+	case v.Fields != nil:
+		fieldsStr := []string{}
+		for _, field := range *v.Fields {
+			fieldsStr = append(fieldsStr, field.Value.String())
+		}
+
+		return fmt.Sprintf("{ %s }", strings.Join(fieldsStr, ", "))
 	}
 
 	return ""
@@ -59,7 +65,7 @@ func (v Value) Type() string {
 	case v.Number != nil:
 		return "number"
 
-	case v.Field != nil:
+	case v.Fields != nil:
 		return "field"
 	}
 


### PR DESCRIPTION
Now specified like this:
```
modules {
	memory {
		retrieval { spreading_activation: 0.5 }
	}
}
```
Part of #325