### PR TITLE
Check for an initialization error with spreading activation

### DIFF
--- a/actr/buffer/buffer.go
+++ b/actr/buffer/buffer.go
@@ -23,8 +23,9 @@ type buffer struct {
 	name string
 
 	// "spreading_activation": see "Spreading Activation" in "ACT-R 7.26 Reference Manual" pg. 290
-	// The default is set when creating the buffer and may be overridden in the config.
 	spreadingActivation float64
+	// The defaultSpreadingActivation is set when creating the buffer and may be overridden in the config.
+	defaultSpreadingActivation float64
 
 	// Any parameters this buffer has
 	parameters param.ParametersInterface
@@ -36,7 +37,7 @@ type buffer struct {
 type Interface interface {
 	Name() string
 
-	SetSpreadingActivation(activation float64)
+	DefaultSpreadingActivation() float64
 	SpreadingActivation() float64
 
 	Parameters() param.ParametersInterface
@@ -70,9 +71,10 @@ func NewBuffer(name string, spreadingActivation float64, requestParameters param
 	})
 
 	newBuffer := &buffer{
-		name:              name,
-		parameters:        parameters,
-		requestParameters: requestParameters,
+		name:                       name,
+		defaultSpreadingActivation: spreadingActivation,
+		parameters:                 parameters,
+		requestParameters:          requestParameters,
 	}
 
 	err := newBuffer.SetParam(&keyvalue.KeyValue{
@@ -91,19 +93,10 @@ func NewBuffer(name string, spreadingActivation float64, requestParameters param
 	return newBuffer
 }
 
-func (b buffer) Name() string {
-	return b.name
-}
-
-func (b *buffer) SetSpreadingActivation(activation float64) { b.spreadingActivation = activation }
-
-func (b buffer) SpreadingActivation() float64 {
-	return b.spreadingActivation
-}
-
-func (b buffer) Parameters() param.ParametersInterface {
-	return b.parameters
-}
+func (b buffer) Name() string                          { return b.name }
+func (b buffer) SpreadingActivation() float64          { return b.spreadingActivation }
+func (b buffer) DefaultSpreadingActivation() float64   { return b.defaultSpreadingActivation }
+func (b buffer) Parameters() param.ParametersInterface { return b.parameters }
 
 func (b *buffer) SetParam(param *keyvalue.KeyValue) (err error) {
 	err = b.Parameters().ValidateParam(param)
@@ -120,9 +113,7 @@ func (b *buffer) SetParam(param *keyvalue.KeyValue) (err error) {
 	return
 }
 
-func (b buffer) RequestParameters() param.ParametersInterface {
-	return b.requestParameters
-}
+func (b buffer) RequestParameters() param.ParametersInterface { return b.requestParameters }
 
 func (b buffer) SetRequestParam(param *keyvalue.KeyValue) (err error) {
 	err = b.RequestParameters().ValidateParam(param)

--- a/amod/amod.go
+++ b/amod/amod.go
@@ -176,9 +176,9 @@ func addConfig(model *actr.Model, log *issueLog, config *configSection) {
 		return
 	}
 
-	addGACTAR(model, log, config.GACTAR)
-	addModules(model, log, config.Modules)
-	addChunks(model, log, config.ChunkDecls)
+	addGACTAR(model, log, config.GactarConfig)
+	addModules(model, log, config.ModuleConfig)
+	addChunks(model, log, config.ChunkConfig)
 }
 
 func addExamples(model *actr.Model, log *issueLog, examples []*pattern) {
@@ -201,8 +201,13 @@ func addExamples(model *actr.Model, log *issueLog, examples []*pattern) {
 	}
 }
 
-func addGACTAR(model *actr.Model, log *issueLog, list []*field) {
-	if list == nil {
+func addGACTAR(model *actr.Model, log *issueLog, config *gactarConfig) {
+	if config == nil {
+		return
+	}
+
+	list := config.GactarFields
+	if len(list) == 0 {
 		return
 	}
 
@@ -233,8 +238,13 @@ func addGACTAR(model *actr.Model, log *issueLog, list []*field) {
 	}
 }
 
-func addModules(model *actr.Model, log *issueLog, modules []*module) {
-	if modules == nil {
+func addModules(model *actr.Model, log *issueLog, config *moduleConfig) {
+	if config == nil {
+		return
+	}
+
+	modules := config.Modules
+	if len(modules) == 0 {
 		return
 	}
 
@@ -254,6 +264,8 @@ func addModules(model *actr.Model, log *issueLog, modules []*module) {
 			log.errorT(module.Tokens, "unrecognized module in config: '%s'", module.ModuleName)
 		}
 	}
+
+	_ = validateInterModuleInitDependencies(model, log, config)
 }
 
 func setBufferParams(moduleName string, buffer buffer.Interface, log *issueLog, field *field) {
@@ -359,8 +371,13 @@ func addProcedural(model *actr.Model, log *issueLog, fields []*field) {
 	setModuleParams(model.Procedural, log, fields)
 }
 
-func addChunks(model *actr.Model, log *issueLog, chunks []*chunkDecl) {
-	if chunks == nil {
+func addChunks(model *actr.Model, log *issueLog, config *chunkConfig) {
+	if config == nil {
+		return
+	}
+
+	chunks := config.ChunkDecls
+	if len(chunks) == 0 {
 		return
 	}
 

--- a/amod/amod_config_test.go
+++ b/amod/amod_config_test.go
@@ -184,6 +184,7 @@ func Example_modulesInitBuffer() {
 	~~ config ~~
 	modules {
 		memory {
+			max_spread_strength: 0.9
 			retrieval { spreading_activation: 0.5 }
 		}
 	}
@@ -191,6 +192,23 @@ func Example_modulesInitBuffer() {
 	~~ productions ~~`)
 
 	// Output:
+}
+
+func Example_modulesInitBufferNoMaxSpread() {
+	generateToStdout(`
+	~~ model ~~
+	name: Test
+	~~ config ~~
+	modules {
+		imaginal {
+			imaginal { spreading_activation: 0.5 }
+		}
+	}
+	~~ init ~~
+	~~ productions ~~`)
+
+	// Output:
+	// ERROR: spreading_activation set on buffer "imaginal", but max_spread_strength not set on memory module (line 5, col 1)
 }
 
 func Example_modulesUnrecognized() {
@@ -214,7 +232,12 @@ func Example_modulesAll() {
 	name: Test
 	~~ config ~~
 	modules {
-		imaginal { delay: 0.2 }
+		imaginal {
+			delay: 0.2
+			imaginal {
+				spreading_activation: 0.5
+			} 
+		}
 		memory {
 			latency_factor: 0.5
 			latency_exponent: 0.75
@@ -225,9 +248,15 @@ func Example_modulesAll() {
 			max_spread_strength: 0.9
 			instantaneous_noise: 0.5
 			mismatch_penalty: 1.0
+			retrieval {
+				spreading_activation: 0.5
+			} 
 		}
 		procedural {
 			default_action_time: 0.06
+		}
+		goal{
+			goal { spreading_activation: 0.5 }
 		}
 	}
 	~~ init ~~

--- a/amod/parse.go
+++ b/amod/parse.go
@@ -120,11 +120,8 @@ type field struct {
 	Tokens []lexer.Token
 }
 
-type chunkDecl struct {
-	StartBracket string   `parser:"'['"` // not used - must be set for parse
-	TypeName     string   `parser:"@Ident ':'"`
-	Slots        []string `parser:"@Ident+"`
-	EndBracket   string   `parser:"']'"` // not used - must be set for parse
+type gactarConfig struct {
+	GactarFields []*field `parser:"'gactar' '{' @@* '}'"`
 
 	Tokens []lexer.Token
 }
@@ -136,10 +133,31 @@ type module struct {
 	Tokens []lexer.Token
 }
 
+type moduleConfig struct {
+	Modules []*module `parser:"'modules' '{' @@* '}'"`
+
+	Tokens []lexer.Token
+}
+
+type chunkDecl struct {
+	StartBracket string   `parser:"'['"` // not used - must be set for parse
+	TypeName     string   `parser:"@Ident ':'"`
+	Slots        []string `parser:"@Ident+"`
+	EndBracket   string   `parser:"']'"` // not used - must be set for parse
+
+	Tokens []lexer.Token
+}
+
+type chunkConfig struct {
+	ChunkDecls []*chunkDecl `parser:"'chunks' '{' @@* '}'"`
+
+	Tokens []lexer.Token
+}
+
 type configSection struct {
-	GACTAR     []*field     `parser:"('gactar' '{' @@* '}')?"`
-	Modules    []*module    `parser:"('modules' '{' @@* '}')?"`
-	ChunkDecls []*chunkDecl `parser:"('chunks' '{' @@* '}')?"`
+	GactarConfig *gactarConfig `parser:"@@?"`
+	ModuleConfig *moduleConfig `parser:"@@?"`
+	ChunkConfig  *chunkConfig  `parser:"@@?"`
 
 	Tokens []lexer.Token
 }

--- a/amod/validate.go
+++ b/amod/validate.go
@@ -100,6 +100,24 @@ func validateModuleInitialization(model *actr.Model, log *issueLog, init *module
 	return
 }
 
+// validateInterModuleInitDependencies checks for inconsistent options set between modules
+func validateInterModuleInitDependencies(model *actr.Model, log *issueLog, config *moduleConfig) (err error) {
+	// when max_spread_strength is not set on memory, check for spreading_activation set on any buffer
+	if model.Memory.MaxSpreadStrength == nil {
+		bufferNames := model.BufferNames()
+
+		for _, name := range bufferNames {
+			buffer := model.LookupBuffer(name)
+			if buffer.SpreadingActivation() != buffer.DefaultSpreadingActivation() {
+				log.errorTR(config.Tokens, 0, 1, "spreading_activation set on buffer %q, but max_spread_strength not set on memory module", name)
+				err = ErrCompile
+			}
+		}
+	}
+
+	return
+}
+
 // validatePattern ensures that the pattern's chunk exists and that its number of slots match.
 func validatePattern(model *actr.Model, log *issueLog, pattern *pattern) (err error) {
 	chunkName := pattern.ChunkName

--- a/doc/amod EBNF.txt
+++ b/doc/amod EBNF.txt
@@ -15,7 +15,10 @@ PatternSlot
            | wildcard
 
 ConfigSection
-         ::= ( 'gactar' '{' Field* '}' )? ( 'modules' '{' Module* '}' )? ( 'chunks' '{' ChunkDecl* '}' )?
+         ::= GactarConfig? ModuleConfig? ChunkConfig?
+
+GactarConfig
+         ::= 'gactar' '{' Field* '}'
 
 Field    ::= ident FieldValue
 
@@ -23,7 +26,13 @@ FieldValue
          ::= ':' ( ident | string | number )
            | '{' Field* '}'
 
+ModuleConfig
+         ::= 'modules' '{' Module* '}'
+
 Module   ::= ident '{' Field* '}'
+
+ChunkConfig
+         ::= 'chunks' '{' ChunkDecl* '}'
 
 ChunkDecl
          ::= '[' ident ':' ident+ ']'


### PR DESCRIPTION
Checks case where spreading_activation is set on a buffer, but max_spread_strength not set on memory module.

Setting max_spread_strength turns on the spreading activation calculation.

This also slightly changes the parsing of the config section for better error reporting.