### PR TITLE
{pyactr} Clean up methods for adding printing

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -33,6 +33,7 @@
     "gosec",
     "Infof",
     "Infoln",
+    "itemlist",
     "keyvalue",
     "Naur",
     "productionstring",

--- a/framework/pyactr/pyactr.go
+++ b/framework/pyactr/pyactr.go
@@ -254,7 +254,7 @@ func (p *PyACTR) GenerateCode(initialBuffers framework.InitialBuffers) (code []b
 	if p.model.HasPrintStatement() {
 		p.Writeln("")
 		p.Writeln("# pyactr doesn't handle general printing, so use gactar to add this capability")
-		p.Writeln("pyactr_print.set_model(%s)", p.className)
+		p.Writeln("pyactr_print.PrintBuffer(%s)", p.className)
 	}
 
 	p.Write("\n")
@@ -698,7 +698,7 @@ func (p PyACTR) outputStatement(production *actr.Production, s *actr.Statement) 
 	case s.Print != nil:
 		// Using "goal" here is arbitrary because of the way we monkey patch the python code.
 		// Our "print_text" statement handles its own formatting and lookup.
-		p.Writeln("     !goal>")
+		p.Writeln("     !print>")
 
 		str := make([]string, len(*s.Print.Values))
 
@@ -716,7 +716,7 @@ func (p PyACTR) outputStatement(production *actr.Production, s *actr.Statement) 
 			}
 		}
 
-		p.Writeln("          print_text \"%s\"", strings.Join(str, ", "))
+		p.Writeln("          text \"%s\"", strings.Join(str, ", "))
 
 	case s.Clear != nil:
 		for _, name := range s.Clear.BufferNames {

--- a/framework/pyactr/pyactr_print.py
+++ b/framework/pyactr/pyactr_print.py
@@ -7,14 +7,28 @@ pyactr is limited in what it can print using "show" to one named slot of the buf
         show start
 
 pyactr_print adds the ability to print strings, numbers, and slots (by name) from
-multiple buffers by patching ACTRModel and Buffer. It uses a new command "print_text"
-in productions which takes a string:
+multiple buffers by patching Buffer. It uses a new buffer called "print" with a 
+command "text" which takes a string:
 
-	!goal>
-	    print_text "'Start is ', goal.start, ' and second is ', 'retrieval.second'"
+	!print>
+	    text "'Start is ', goal.start, ' and second is ', 'retrieval.second'"
 
 Unfortunately due to the way pyactr is implemented, we are currently limited to
-one "print"text" statement per production.
+one print command per production. It does, however, allow multiple "text"s in 
+one command:
+
+	!print>
+	    text "'a string'"
+	    text "42"
+
+
+To use this new buffer, construct it passing in the model like this:
+
+    import pyactr_print
+
+    pyactr_print.PrintBuffer(pyactr_fan)
+
+Then you can use it with "!print>" as shown above.
 """
 
 # We use csv to parse the print text we are generating.
@@ -23,33 +37,6 @@ import csv
 import pyactr as actr
 
 from pyactr.buffers import Buffer
-
-# This is generally Bad(tm). This means we can only have one actr.ACTRModel.
-# Unfortunately, there's no way to get from a Buffer to an ACTRModel.
-ACTR_MODEL: actr.ACTRModel
-
-
-def set_model(model: actr.ACTRModel):
-    """
-    Sets our module's ACTR_MODEL so we can access it in Buffer.print_text.
-    """
-    global ACTR_MODEL
-    ACTR_MODEL = model
-
-
-def get_buffer(self, buffer_name: str) -> Buffer:
-    """
-    Gets a buffer from a name and returns it.
-    """
-    if buffer_name in self._ACTRModel__buffers:
-        return self._ACTRModel__buffers[buffer_name]
-
-    print('ERROR: Buffer \'' + buffer_name + '\' not found')
-    raise KeyError
-
-
-# Monkey patch ACTRModel to add a new method.
-actr.ACTRModel.get_buffer = get_buffer
 
 
 def get_slot_contents(self, buffer_name: str, slot_name: str) -> str:
@@ -69,39 +56,74 @@ def get_slot_contents(self, buffer_name: str, slot_name: str) -> str:
         raise
 
 
-def print_text(*args):
-    """
-    Prints the args - including strings, numbers, and slots (by name).
-    """
-    text = ''.join(args[1:]).strip('"')
-    output = ''  # build up our output in this buffer
-
-    for itemlist in csv.reader([text]):
-        for item in itemlist:
-            item = item.strip(' ')
-
-            # Handle string
-            if item[0] == '\'' or item[0] == '"':
-                output += item[1:-1]
-            else:
-                # Handle number
-                try:
-                    float(item)
-                    output += item
-                except ValueError:
-                    # If we are here, we should have a buffer.slotname
-                    ids = item.split('.')
-                    if len(ids) != 2:
-                        print(
-                            'ERROR: expected <buffer>.<slot_name>, found \'' +
-                            item + '\'')
-                    else:
-                        buffer = ACTR_MODEL.get_buffer(ids[0])
-                        output += buffer.get_slot_contents(ids[0], ids[1])
-
-    print(output)
-
-
-# Monkey patch Buffer to add a new methods.
+# Monkey patch Buffer to add a new method.
 Buffer.get_slot_contents = get_slot_contents
-Buffer.print_text = print_text
+
+
+class PrintBuffer(actr.buffers.Buffer):
+    def __init__(self, model: actr.ACTRModel):
+        actr.buffers.Buffer.__init__(self, None, None)
+        self.ACTR_MODEL = model
+        model._ACTRModel__buffers["print"] = self
+
+    def text(self, *args):
+        """
+        Prints the args - including strings, numbers, and slots (by name).
+        """
+        text = ''.join(args[1:]).strip('"')
+        output = ''  # build up our output in this buffer
+
+        for itemlist in csv.reader([text]):
+            for item in itemlist:
+                item = item.strip(' ')
+
+                # Handle string
+                if item[0] == '\'' or item[0] == '"':
+                    output += item[1:-1]
+                else:
+                    # Handle number
+                    try:
+                        float(item)
+                        output += item
+                    except ValueError:
+                        # If we are here, we should have a buffer.slotname
+                        ids = item.split('.')
+                        if len(ids) != 2:
+                            print(
+                                'ERROR: expected <buffer>.<slot_name>, found \'' +
+                                item + '\'')
+                        else:
+                            buffer = self.get_buffer(ids[0])
+                            output += buffer.get_slot_contents(ids[0], ids[1])
+
+        print(output)
+
+    def get_buffer(self, buffer_name: str) -> Buffer:
+        """
+        Gets a buffer by name and returns it.
+        """
+        if buffer_name in self.ACTR_MODEL._ACTRModel__buffers:
+            return self.ACTR_MODEL._ACTRModel__buffers[buffer_name]
+
+        print('ERROR: Buffer \'' + buffer_name + '\' not found')
+        raise KeyError
+
+    def add(self, *args):
+        raise AttributeError(
+            "Attempt to add an element to the print buffer. This is not allowed.")
+
+    def clear(self, *args):
+        raise AttributeError(
+            "Attempt to clear the print buffer. This is not allowed.")
+
+    def create(self, *args):
+        raise AttributeError(
+            "Attempt to add an element to the print buffer. This is not allowed.")
+
+    def retrieve(self, *args):
+        raise AttributeError(
+            "Attempt to retrieve from the print buffer. This is not allowed.")
+
+    def test(self, *args):
+        raise AttributeError(
+            "Attempt to test the print buffer state. This is not allowed.")


### PR DESCRIPTION
- implements printing using a new PrintBuffer (which isn't really a buffer; it just allows us to run a command using "!print>")
- removes monkey-patching of model
- we now only patch "Buffer" for getting a slot's contents