### PR TITLE
Separate run options from model

### DIFF
--- a/actr/model.go
+++ b/actr/model.go
@@ -44,7 +44,9 @@ type Model struct {
 
 	Productions []*Production
 
-	runoptions.Options
+	// These defaults come from the amod file and may be overridden on the command line
+	// or by web requests.
+	DefaultParams runoptions.Options
 
 	// Used to validate our parameters
 	parameters param.ParametersInterface
@@ -80,7 +82,7 @@ func (model *Model) Initialize() {
 	model.Procedural = modules.NewProcedural()
 	model.Modules = append(model.Modules, model.Procedural)
 
-	model.LogLevel = "info"
+	model.DefaultParams = runoptions.New()
 
 	// Declare our parameters
 	loggingParam := param.NewStr(
@@ -293,16 +295,16 @@ func (model *Model) SetParam(kv *keyvalue.KeyValue) (err error) {
 
 	switch kv.Key {
 	case "log_level":
-		model.LogLevel = runoptions.ACTRLogLevel(*value.Str)
+		model.DefaultParams.LogLevel = runoptions.ACTRLogLevel(*value.Str)
 
 	case "trace_activations":
 		boolVal, _ := value.AsBool() // already validated
-		model.TraceActivations = boolVal
+		model.DefaultParams.TraceActivations = boolVal
 
 	case "random_seed":
 		seed := uint32(*value.Number)
 
-		model.RandomSeed = &seed
+		model.DefaultParams.RandomSeed = &seed
 
 	default:
 		return param.ErrUnrecognizedOption{Option: kv.Key}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -7,6 +7,7 @@ import (
 	"github.com/asmaloney/gactar/actr"
 
 	"github.com/asmaloney/gactar/util/issues"
+	"github.com/asmaloney/gactar/util/runoptions"
 	"github.com/asmaloney/gactar/util/version"
 )
 
@@ -50,9 +51,9 @@ type Framework interface {
 	SetModel(model *actr.Model) (err error)
 	Model() (model *actr.Model)
 
-	Run(initialBuffers InitialBuffers) (result *RunResult, err error)
-	WriteModel(path string, initialBuffers InitialBuffers) (outputFileName string, err error)
-	GenerateCode(initialBuffers InitialBuffers) (code []byte, err error)
+	Run(options *runoptions.Options, initialBuffers InitialBuffers) (result *RunResult, err error)
+	WriteModel(path string, options *runoptions.Options, initialBuffers InitialBuffers) (outputFileName string, err error)
+	GenerateCode(options *runoptions.Options, initialBuffers InitialBuffers) (code []byte, err error)
 }
 
 type List map[string]Framework

--- a/framework/tools.go
+++ b/framework/tools.go
@@ -43,7 +43,7 @@ func GenerateCodeFromFile(fw Framework, inputFile string, initialBuffers Initial
 		return
 	}
 
-	code, err = fw.GenerateCode(initialBuffers)
+	code, err = fw.GenerateCode(&model.DefaultParams, initialBuffers)
 	if err != nil {
 		return
 	}

--- a/modes/defaultmode/defaultmode.go
+++ b/modes/defaultmode/defaultmode.go
@@ -113,7 +113,7 @@ func generateCode(frameworks framework.List, files []string, outputDir string) (
 				continue
 			}
 
-			fileName, err := f.WriteModel(outputDir, framework.InitialBuffers{})
+			fileName, err := f.WriteModel(outputDir, &model.DefaultParams, framework.InitialBuffers{})
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
@@ -127,7 +127,8 @@ func generateCode(frameworks framework.List, files []string, outputDir string) (
 
 func runCode(frameworks framework.List) {
 	for _, f := range frameworks {
-		result, err := f.Run(framework.InitialBuffers{})
+		model := f.Model()
+		result, err := f.Run(&model.DefaultParams, framework.InitialBuffers{})
 		if err != nil {
 			fmt.Println(err.Error())
 			continue

--- a/modes/shell/shell.go
+++ b/modes/shell/shell.go
@@ -264,7 +264,7 @@ func (s *Shell) cmdRun(initialGoal string) (err error) {
 			"goal": strings.TrimSpace(initialGoal),
 		}
 
-		result, err := f.Run(initialBuffers)
+		result, err := f.Run(&s.currentModel.DefaultParams, initialBuffers)
 		if err != nil {
 			return err
 		}

--- a/modes/web/model.go
+++ b/modes/web/model.go
@@ -83,10 +83,10 @@ func (w *Web) loadModel(sessionID int, amodFile string) (model *Model, err error
 	return
 }
 
-// actrOptionsFromJSON converts runOptionsJSON into actr.Options
-func (w Web) actrOptionsFromJSON(options *runOptionsJSON) (runoptions.Options, error) {
+// actrOptionsFromJSON converts runOptionsJSON into actr.Options. It defaults to the model's defaults.
+func (w Web) actrOptionsFromJSON(defaults *runoptions.Options, options *runOptionsJSON) (*runoptions.Options, error) {
 	if options == nil {
-		return runoptions.Options{}, nil
+		return nil, nil
 	}
 
 	activeFrameworkNames := w.settings.Frameworks.Names()
@@ -95,13 +95,12 @@ func (w Web) actrOptionsFromJSON(options *runOptionsJSON) (runoptions.Options, e
 
 	err := options.Frameworks.VerifyFrameworkList(activeFrameworkNames)
 	if err != nil {
-		return runoptions.Options{}, err
+		return nil, err
 	}
 
-	opts := runoptions.New()
+	opts := *defaults
 
 	opts.Frameworks = options.Frameworks
-	opts.RandomSeed = options.RandomSeed
 
 	if options.LogLevel != nil {
 		opts.LogLevel = runoptions.ACTRLogLevel(*options.LogLevel)
@@ -111,7 +110,9 @@ func (w Web) actrOptionsFromJSON(options *runOptionsJSON) (runoptions.Options, e
 		opts.TraceActivations = *options.TraceActivations
 	}
 
-	return opts, nil
+	opts.RandomSeed = options.RandomSeed
+
+	return &opts, nil
 }
 
 func generateModel(amodFile string) (model *actr.Model, err error) {

--- a/modes/web/session.go
+++ b/modes/web/session.go
@@ -67,13 +67,11 @@ func (w *Web) runModelSessionHandler(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	aoptions, err := w.actrOptionsFromJSON(&data.Options)
+	aoptions, err := w.actrOptionsFromJSON(&model.actrModel.DefaultParams, &data.Options)
 	if err != nil {
 		encodeErrorResponse(rw, err)
 		return
 	}
-
-	model.actrModel.Options = aoptions
 
 	// ensure temp dir exists
 	// https://github.com/asmaloney/gactar/issues/103
@@ -83,7 +81,7 @@ func (w *Web) runModelSessionHandler(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	resultMap := w.runModel(model.actrModel, data.Buffers)
+	resultMap := w.runModel(model.actrModel, aoptions, data.Buffers)
 
 	for key := range resultMap {
 		result := resultMap[key]

--- a/util/runoptions/runoptions.go
+++ b/util/runoptions/runoptions.go
@@ -37,7 +37,7 @@ type Options struct {
 	// One of 'min', 'info', or 'detail'
 	LogLevel ACTRLogLevel
 
-	// Output detailed info about activations
+	// If true, output detailed info about activations
 	TraceActivations bool
 
 	// The seed to use for generating pseudo-random numbers (allows for reproducible runs)


### PR DESCRIPTION
Instead of storing them directly on the model, pass them as a param.

The model now stores the default which come from the amod file. These may overridden by the command line or the web API.